### PR TITLE
Feature: 플러그인 온보딩 구현

### DIFF
--- a/src/constants/timeConstants.js
+++ b/src/constants/timeConstants.js
@@ -1,0 +1,5 @@
+const DELAY_TIME = {
+  POLLING: 2000,
+};
+
+export default DELAY_TIME;

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -1,1 +1,7 @@
 figma.showUI(__html__, { width: 400, height: 540 });
+
+figma.ui.onmessage = async message => {
+  if (message.type === "SAVE_ACCESS_TOKEN") {
+    await figma.clientStorage.setAsync("accessToken", message.content);
+  }
+};

--- a/src/services/getAuth.js
+++ b/src/services/getAuth.js
@@ -24,9 +24,9 @@ const getToken = async () => {
   const API_URI = generateApiUri(serverURI, "oauth/accesstoken");
 
   const response = await fetch(API_URI, { method: "GET" });
-  const { accessToken } = await response.json();
+  const responseJSON = await response.json();
 
-  return accessToken;
+  return responseJSON;
 };
 
 export { openAuth, getToken };

--- a/src/services/getAuth.js
+++ b/src/services/getAuth.js
@@ -1,0 +1,32 @@
+import generateApiUri from "../utils/generateURI";
+
+const clientId = import.meta.env.VITE_FIGMA_CLIENT_ID;
+const figmaURI = import.meta.env.VITE_FIGMA_BASE_API_URI;
+const serverURI = import.meta.env.VITE_BACKEND_BASE_API_URI;
+const redirectURI = import.meta.env.VITE_FIGMA_REDIRECT_URI;
+const oAuthState = import.meta.env.VITE_FIGMA_OAUTH_STATE;
+
+const openAuth = () => {
+  const queryParams = {
+    client_id: clientId,
+    redirect_uri: redirectURI,
+    scope: "files:read",
+    state: oAuthState,
+    response_type: "code",
+  };
+
+  const API_URI = generateApiUri(figmaURI, "oauth", queryParams);
+
+  window.open(API_URI);
+};
+
+const getToken = async () => {
+  const API_URI = generateApiUri(serverURI, "oauth/accesstoken");
+
+  const response = await fetch(API_URI, { method: "GET" });
+  const { accessToken } = await response.json();
+
+  return accessToken;
+};
+
+export { openAuth, getToken };

--- a/src/ui/components/Onboarding/index.jsx
+++ b/src/ui/components/Onboarding/index.jsx
@@ -23,7 +23,7 @@ function Onboarding() {
 
   const getTokenPolling = () => {
     const pollingId = setInterval(async () => {
-      const accessToken = await getToken();
+      const { content: accessToken } = await getToken();
 
       if (accessToken) {
         setAccessToken(accessToken);

--- a/src/ui/components/Onboarding/index.jsx
+++ b/src/ui/components/Onboarding/index.jsx
@@ -1,5 +1,90 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+
+import Container from "../shared/Container";
+import Button from "../shared/Button";
+
+import figciLogo from "../../../../assets/logo_figci.png";
+import { openAuth, getToken } from "../../../services/getAuth";
+
 function Onboarding() {
-  return <h1>Onboarding</h1>;
+  const navigate = useNavigate();
+  const [isClicked, setIsClicked] = useState(false);
+  const [accessToken, setAccessToken] = useState("");
+
+  const onLoginClick = ev => {
+    ev.preventDefault();
+
+    setIsClicked(true);
+  };
+
+  const getTokenPolling = () => {
+    const pollingId = setInterval(async () => {
+      const accessToken = await getToken();
+
+      if (accessToken) {
+        setAccessToken(accessToken);
+        clearInterval(pollingId);
+      }
+    }, 2000);
+  };
+
+  useEffect(() => {
+    if (isClicked) {
+      openAuth();
+      getTokenPolling();
+
+      setIsClicked(false);
+    }
+
+    return;
+  }, [isClicked]);
+
+  useEffect(() => {
+    if (accessToken) {
+      window.parent.postMessage(
+        {
+          pluginMessage: {
+            type: "SAVE_ACCESS_TOKEN",
+            accessToken,
+          },
+        },
+        "*",
+      );
+
+      navigate("/new");
+    }
+  }, [accessToken]);
+
+  return (
+    <Container>
+      <LogoImage className="logo-icon" src={figciLogo} alt="figci-logo-icon" />
+      <Description className="description">
+        이전 버전과 현재 실행중인 프로젝트 버전과 비교해서
+        <br />
+        디자인 화면의 변경사항을 한눈에 보여드려요!
+      </Description>
+      <Button className="login-button" handleClick={onLoginClick} size="medium">
+        로그인 하기
+      </Button>
+    </Container>
+  );
 }
+
+const LogoImage = styled.img`
+  width: 145px;
+  margin-bottom: 24px;
+`;
+
+const Description = styled.span`
+  display: block;
+  margin-bottom: 36px;
+
+  font-size: 1rem;
+  color: #343e40;
+  text-align: center;
+  line-height: 24px;
+`;
 
 export default Onboarding;

--- a/src/ui/components/Onboarding/index.jsx
+++ b/src/ui/components/Onboarding/index.jsx
@@ -7,6 +7,7 @@ import Button from "../shared/Button";
 
 import figciLogo from "../../../../assets/logo_figci.png";
 import { openAuth, getToken } from "../../../services/getAuth";
+import postMessage from "../../../utils/postMessage";
 
 function Onboarding() {
   const navigate = useNavigate();
@@ -43,15 +44,7 @@ function Onboarding() {
 
   useEffect(() => {
     if (accessToken) {
-      window.parent.postMessage(
-        {
-          pluginMessage: {
-            type: "SAVE_ACCESS_TOKEN",
-            accessToken,
-          },
-        },
-        "*",
-      );
+      postMessage("SAVE_ACCESS_TOKEN", accessToken);
 
       navigate("/new");
     }

--- a/src/ui/components/Onboarding/index.jsx
+++ b/src/ui/components/Onboarding/index.jsx
@@ -8,6 +8,7 @@ import Button from "../shared/Button";
 import figciLogo from "../../../../assets/logo_figci.png";
 import { openAuth, getToken } from "../../../services/getAuth";
 import postMessage from "../../../utils/postMessage";
+import DELAY_TIME from "../../../constants/timeConstants";
 
 function Onboarding() {
   const navigate = useNavigate();
@@ -28,7 +29,7 @@ function Onboarding() {
         setAccessToken(accessToken);
         clearInterval(pollingId);
       }
-    }, 2000);
+    }, DELAY_TIME.POLLING);
   };
 
   useEffect(() => {
@@ -74,8 +75,8 @@ const Description = styled.span`
   display: block;
   margin-bottom: 36px;
 
-  font-size: 1rem;
   color: #343e40;
+  font-size: 1rem;
   text-align: center;
   line-height: 24px;
 `;

--- a/src/ui/components/shared/Button.jsx
+++ b/src/ui/components/shared/Button.jsx
@@ -11,8 +11,8 @@ const BUTTON_SIZES = {
     --button-radius: 4px;
   `,
   medium: css`
-    --button-min-width: 320px;
-    --button-min-height: 65px;
+    --button-min-width: 350px;
+    --button-min-height: 45px;
     --button-font-size: 0.875rem;
     --button-padding: 12px 24px;
     --button-border: 1px solid #000000;

--- a/src/ui/components/shared/Container.jsx
+++ b/src/ui/components/shared/Container.jsx
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+
+function Container({ children }) {
+  return <StyledContainer>{children}</StyledContainer>;
+}
+
+const StyledContainer = styled.div`
+  box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  padding: 24px;
+`;
+
+export default Container;

--- a/src/utils/postMessage.js
+++ b/src/utils/postMessage.js
@@ -1,0 +1,13 @@
+const postMessage = (type, content, origin = "*") => {
+  window.parent.postMessage(
+    {
+      pluginMessage: {
+        type,
+        content,
+      },
+    },
+    origin,
+  );
+};
+
+export default postMessage;


### PR DESCRIPTION
## Fix (이슈 번호)
closes #2 

<br />

## 해결하려던 문제를 알려주세요!
1. 플러그인 환경 온보딩 페이지를 구현하기
2. `iframe` 환경에서 `OAuth2` 인증 구현하기
3. `postMessage`를 통해서 샌드박스에 토큰 저장

### 만났던 에러
1. 
![image](https://github.com/Figci/Figci-Plugin-Client/assets/48385389/5724b33b-189d-4fcc-9c4d-4bbc192688cb)
→ UI에서 server로 fetch를 보낼 때 나타났던 에러

2. 
![image](https://github.com/Figci/Figci-Plugin-Client/assets/48385389/7e1f5795-22ca-45d5-a5f9-ae781158b945)
→ UI에서 server로 fetch를 보낼 때 나타났던 에러2

<br />

## 어떻게 해결했나요?
1. **_`react`를 사용하여 웹페이지와 동일하게 구현 하였습니다._**

<br/>

2. **_기본적으로 `OAuth`는 `redirect`을 통해 인증을 진행하게 됩니다._**
허나,  플러그인 이라는 특수한 환경은 `iframe`위에 렌더되기 떄문에 `redirect`가 불가합니다.
따라서 `OAuth`의 `callback URL`을 서버로 우회하여 `OAuth`인증을 서버에서 진행했습니다.
이때 마주했던 문제점중에 하나가 결국 인증을 진행하는 주체는 `백엔드 서버 - Figma Authrization 서버` 였기때문에
해당 토큰을 어떻게 UI로 보내줄 수 있을까를 심도있게 고민했습니다.
`백엔드 서버 - Figma Authrization 서버의 request-response cycle`중에는 UI로 해당 토큰을 보낼 방법이 없었기 때문입니다.
따라서 서버가 인증을 완료해서 토큰을 받게 되면 잠시동안 토큰값을 캐싱 해놓고 UI에서는 `polling`방식을 통해서 서버에서 받은 `accessToken`을 받아올 수 있게끔 구현했습니다.

많이 도움이 되었던 링크 첨부드립니다.
[OAuth with Plugins](https://www.figma.com/plugin-docs/oauth-with-plugins/)
[How to make next-level Figma plugins: auth, routing, storage, and more](https://evilmartians.com/chronicles/how-to-make-next-level-figma-plugins-auth-routing-storage-and-more)

<br/>

3. **_plugin환경에서 UI와 `sandBox`는 window전역 객체의 `postMessage`메서드를 활용해서 통신을 하기 때문에, 해당 메서드를 이용했습니다._**

<br />

### 에러 해결 방법
1. **_CSP 에러_**
→ 이는 서버로 fetch를 전송할 때 만났던 에러입니다.
plugin환경에서는 `manifest`라는 json파일에 `networkAccess`라는 프로퍼티로 통신할 도메인을 명시적으로 작성해서 허용해주어야.
기본값은 "none"인데, 이렇게 되면 외부 와 통신을 전혀 하지 못하게 됩니다.
따라서 서버 도메인을 명시적으로 추가해서 해결 했습니다.

**_"CSP 오류를 확인하면 네트워크 액세스 제한 단계에 따라 "none"을 제거하고
플러그인에 필요한 도메인을 허용된 도메인 목록에 추가합니다."_** - Figma 공식문서
```js
{
  "name": "Figci_Plugin",
  "id": "1339982367203490154",
  "api": "1.0.0",
  "main": "src/plugin/code.js",
  "capabilities": [],
  "enableProposedApi": false,
  "editorType": ["figma"],
  "ui": "dist/index.html",
  "networkAccess": {
    "allowedDomains": ["none"],
    "devAllowedDomains": ["http://localhost:3000"]
  }
}
```
[Plugin Manifest](https://www.figma.com/plugin-docs/manifest/)
[Making Network Requests](https://www.figma.com/plugin-docs/making-network-requests/)

<br/>

2. **_CORS 에러_**
→ plugin은 iframe환경에서 실행되고, 해당 origin은 null이기 때문에, `cors origin`을 `*`로 설정해 둔 서버의 API만 호출 가능합니다.
기존의 저희 서버에는 `cors origin`이 `localhost:5173`으로 되어있었기 때문에 `*`로 수정함으로써 해결 했습니다.
![image](https://github.com/Figci/Figci-Plugin-Client/assets/48385389/1de8764a-7cc5-40b3-b9b1-7fa2e5e4f18b)
→ [해당 문서](https://www.figma.com/plugin-docs/making-network-requests/#:~:text=Because%20plugins%20run%20inside%20a%20browser%20environment%2C%20Cross%2DOrigin%20Resource%20Sharing%20policies%20apply.%20Plugin%20iframes%20have%20a%20null%20origin.%20This%20means%20that%20they%20will%20only%20be%20able%20to%20call%20APIs%20with%20Access%2DControl%2DAllow%2DOrigin%3A%20*%20(i.e.%2C%20those%20that%20allow%20access%20from%20any%20origin).)

<br/>

## 우려사항이 있나요?(선택사항)
1. 서버 cors설정 origin을 *로 변경했습니다.
2. 플러그인 OAuth 인증 우회를 위해 OAuth 라우터를 추가 했습니다. (PR 올릴 예정)
3. plugin 로그인 시 connect 화면을 구현하기 위해 pug를 추가했습니다.
4. **_❗️FE와 BE `.env`에 추가된 사항이 몇가지 있습니다. 개별적으로 공유하겠습니다!!_**

<br/>

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 
![image](https://github.com/Figci/Figci-Plugin-Client/assets/48385389/ccca5e50-16cb-4ba0-8abb-49a8aa49f8d4)
→ OAuth 인증 완료 후 표시되는 connect 화면
