### PR TITLE
Feat: 프로젝트 URL 입력 페이지 구현  및 버전 컴포넌트 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.5",
     "lint-staged": "^15.2.2",
+    "nanoid": "^5.0.5",
     "prettier": "^3.2.5",
     "vite": "^5.1.0",
     "vite-plugin-singlefile": "^2.0.0",

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -4,4 +4,13 @@ figma.ui.onmessage = async message => {
   if (message.type === "SAVE_ACCESS_TOKEN") {
     await figma.clientStorage.setAsync("accessToken", message.content);
   }
+
+  if (message.type === "GET_ACCESS_TOKEN") {
+    const accessToken = await figma.clientStorage.getAsync("accessToken");
+
+    figma.ui.postMessage({
+      type: "GET_ACCESS_TOKEN",
+      content: accessToken,
+    });
+  }
 };

--- a/src/service/getAllVersions.js
+++ b/src/service/getAllVersions.js
@@ -1,0 +1,21 @@
+import generateApiUri from "../utils/generateURI";
+
+const baseURI = import.meta.env.VITE_BACKEND_BASE_API_URI;
+
+const getAllVersions = async projectsId => {
+  const token = JSON.parse(localStorage.getItem("FigmaToken")).access_token;
+  const API_URI = generateApiUri(baseURI, `projects/${projectsId}/versions`);
+
+  const response = await fetch(API_URI, {
+    method: "GET",
+    headers: {
+      authorization: token,
+    },
+  });
+
+  const responseResult = await response.json();
+
+  return responseResult;
+};
+
+export default getAllVersions;

--- a/src/service/getAllVersions.js
+++ b/src/service/getAllVersions.js
@@ -2,8 +2,7 @@ import generateApiUri from "../utils/generateURI";
 
 const baseURI = import.meta.env.VITE_BACKEND_BASE_API_URI;
 
-const getAllVersions = async projectsId => {
-  const token = JSON.parse(localStorage.getItem("FigmaToken")).access_token;
+const getAllVersions = async (projectsId, token) => {
   const API_URI = generateApiUri(baseURI, `projects/${projectsId}/versions`);
 
   const response = await fetch(API_URI, {

--- a/src/service/getCommonPages.js
+++ b/src/service/getCommonPages.js
@@ -1,0 +1,31 @@
+import generateApiUri from "../utils/generateURI";
+
+const getCommonPages = async (projectKey, beforeVersion, afterVersion) => {
+  const baseURI = import.meta.env.VITE_BACKEND_BASE_API_URI;
+
+  const token = JSON.parse(localStorage.getItem("FigmaToken")).access_token;
+
+  const queryParams = {
+    "before-version": beforeVersion,
+    "after-version": afterVersion,
+  };
+
+  const API_URI = generateApiUri(
+    baseURI,
+    `projects/${projectKey}/pages`,
+    queryParams,
+  );
+
+  const response = await fetch(API_URI, {
+    method: "GET",
+    headers: {
+      authorization: token,
+    },
+  });
+
+  const responseResult = await response.json();
+
+  return responseResult;
+};
+
+export default getCommonPages;

--- a/src/service/getCommonPages.js
+++ b/src/service/getCommonPages.js
@@ -1,9 +1,12 @@
 import generateApiUri from "../utils/generateURI";
 
-const getCommonPages = async (projectKey, beforeVersion, afterVersion) => {
+const getCommonPages = async (
+  projectKey,
+  beforeVersion,
+  afterVersion,
+  token,
+) => {
   const baseURI = import.meta.env.VITE_BACKEND_BASE_API_URI;
-
-  const token = JSON.parse(localStorage.getItem("FigmaToken")).access_token;
 
   const queryParams = {
     "before-version": beforeVersion,

--- a/src/ui/components/Header/index.jsx
+++ b/src/ui/components/Header/index.jsx
@@ -1,5 +1,27 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import styled from "styled-components";
+
+import figciLogo from "../../../../assets/logo_figci.png";
+
 function Header() {
-  return <h1>Header</h1>;
+  return (
+    <HeadWrapper>
+      <Link to="/">
+        <img className="logo" src={figciLogo} alt="figci-logo-img" />
+      </Link>
+    </HeadWrapper>
+  );
 }
+
+const HeadWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  padding: 32px 24px;
+
+  .logo {
+    height: 20px;
+  }
+`;
 
 export default Header;

--- a/src/ui/components/NewProject/index.jsx
+++ b/src/ui/components/NewProject/index.jsx
@@ -160,7 +160,7 @@ const ContentsWrapper = styled.div`
     height: 100%;
 
     color: #000000;
-    font-size: 0.75rem;
+    font-size: 0.813rem;
     text-align: left;
     line-height: 16px;
     font-weight: 700;

--- a/src/ui/components/NewProject/index.jsx
+++ b/src/ui/components/NewProject/index.jsx
@@ -13,10 +13,10 @@ import isValidFigmaUrl from "../../../utils/isValidFigmaUrl";
 import postMessage from "../../../utils/postMessage";
 
 function NewProject() {
+  const navigate = useNavigate();
+
   const { project, setProject, clearProject } = useProjectStore();
   const { setVersion, clearVersion } = useProjectVersionStore();
-
-  const navigate = useNavigate();
 
   const [inputValue, setInputValue] = useState(null);
   const [toast, setToast] = useState(false);
@@ -36,14 +36,13 @@ function NewProject() {
       const projectKey = getProjectKeyFromURI(inputValue);
 
       const allVersions = await getAllVersions(projectKey, token);
+      const projectUrl = inputValue;
 
       if (allVersions.result === "error") {
         setToast({ status: true, message: allVersions.message });
 
         return;
       }
-
-      const projectUrl = inputValue;
 
       setProject({ projectKey, projectUrl });
       setVersion(allVersions.content);

--- a/src/ui/components/NewProject/index.jsx
+++ b/src/ui/components/NewProject/index.jsx
@@ -7,19 +7,18 @@ import ToastPopup from "../shared/Toast";
 
 import useProjectStore from "../../../store/project";
 import useProjectVersionStore from "../../../store/projectVersion";
+
 import getProjectKeyFromURI from "../../../utils/getProjectKeyfromURI";
-import getAllVersions from "../../../service/getAllVersions";
 import isValidFigmaUrl from "../../../utils/isValidFigmaUrl";
 import postMessage from "../../../utils/postMessage";
+import getAllVersions from "../../../service/getAllVersions";
 
 function NewProject() {
   const navigate = useNavigate();
+  const [toast, setToast] = useState(false);
 
   const { project, setProject, clearProject } = useProjectStore();
   const { setVersion, clearVersion } = useProjectVersionStore();
-
-  const [inputValue, setInputValue] = useState(null);
-  const [toast, setToast] = useState(false);
 
   useEffect(() => {
     clearProject();
@@ -27,16 +26,14 @@ function NewProject() {
   }, []);
 
   const handleChangeInput = ev => {
-    setInputValue(ev.target.value);
+    setProject({ projectUrl: ev.target.value });
   };
 
   const handleMessage = async ev => {
     if (ev.data.pluginMessage.type === "GET_ACCESS_TOKEN") {
       const token = ev.data.pluginMessage.content;
-      const projectKey = getProjectKeyFromURI(inputValue);
-
+      const projectKey = getProjectKeyFromURI(project.projectUrl);
       const allVersions = await getAllVersions(projectKey, token);
-      const projectUrl = inputValue;
 
       if (allVersions.result === "error") {
         setToast({ status: true, message: allVersions.message });
@@ -44,7 +41,7 @@ function NewProject() {
         return;
       }
 
-      setProject({ projectKey, projectUrl });
+      setProject({ projectKey });
       setVersion(allVersions.content);
 
       navigate("/version");
@@ -57,12 +54,12 @@ function NewProject() {
     return () => {
       window.removeEventListener("message", handleMessage);
     };
-  }, [inputValue]);
+  }, [project.projectUrl]);
 
   const handleSubmitURI = async ev => {
     ev.preventDefault();
 
-    if (!isValidFigmaUrl(inputValue)) {
+    if (!isValidFigmaUrl(project.projectUrl)) {
       setToast({
         status: true,
         message: "피그마 파일 URL 주소가 아니에요. 다시 입력해주세요🥲",
@@ -89,21 +86,19 @@ function NewProject() {
             피그마 프로젝트 URL 입력
             <input
               id="projectUrl"
-              defaultValue={inputValue}
+              defaultValue={project.projectUrl}
               placeholder="url 주소를 입력해주세요. (예: www.figma.com/abc)"
               onChange={handleChangeInput}
             />
           </label>
-          <div className="buttons">
-            <Button
-              handleClick={handleSubmitURI}
-              usingCase="solid"
-              size="small"
-              className="next"
-            >
-              다음
-            </Button>
-          </div>
+          <Button
+            handleClick={handleSubmitURI}
+            usingCase="solid"
+            size="small"
+            className="next"
+          >
+            다음
+          </Button>
         </form>
       </ContentsWrapper>
       {toast.status && (
@@ -173,16 +168,6 @@ const ContentsWrapper = styled.div`
 
   Button {
     width: 100%;
-  }
-
-  .description {
-    display: block;
-
-    color: #868e96;
-    font-size: 1rem;
-    font-style: normal;
-    font-weight: 500;
-    line-height: 24px;
   }
 `;
 

--- a/src/ui/components/NewProject/index.jsx
+++ b/src/ui/components/NewProject/index.jsx
@@ -1,5 +1,172 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+
+import Button from "../shared/Button";
+import ToastPopup from "../shared/Toast";
+
+import useProjectStore from "../../../store/project";
+import useProjectVersionStore from "../../../store/projectVersion";
+import getProjectKeyFromURI from "../../../utils/getProjectKeyfromURI";
+import getAllVersions from "../../../service/getAllVersions";
+import isValidFigmaUrl from "../../../utils/isValidFigmaUrl";
+
 function NewProject() {
-  return <h1>NewProject</h1>;
+  const { project, setProject, clearProject } = useProjectStore();
+  const { setVersion, clearVersion } = useProjectVersionStore();
+
+  const navigate = useNavigate();
+
+  const [inputValue, setInputValue] = useState(project.projectUrl);
+  const [toast, setToast] = useState(false);
+
+  useEffect(() => {
+    clearProject();
+    clearVersion();
+  }, []);
+
+  const handleChangeInput = ev => {
+    setInputValue(ev.target.value);
+  };
+
+  const handleSubmitURI = async ev => {
+    ev.preventDefault();
+
+    if (!isValidFigmaUrl(inputValue)) {
+      setToast({
+        status: true,
+        message: "피그마 파일 URL 주소가 아니에요. 다시 입력해주세요🥲",
+      });
+
+      return;
+    }
+
+    const projectKey = getProjectKeyFromURI(inputValue);
+    const allVersions = await getAllVersions(projectKey);
+    const projectUrl = inputValue;
+
+    if (allVersions.result === "error") {
+      setToast({ status: true, message: "allVersions.message" });
+
+      return;
+    }
+
+    setProject({ projectKey, projectUrl });
+    setVersion(allVersions.content);
+
+    navigate("/version");
+  };
+
+  return (
+    <>
+      <ContentsWrapper>
+        <form>
+          <div>
+            <h1 className="step">STEP 01</h1>
+            <h1 className="title">
+              디자인 변경사항을 확인할 <br />
+              피그마 프로젝트 URL을 입력해주세요.
+            </h1>
+          </div>
+          <label htmlFor="projectUrl" className="label">
+            피그마 프로젝트 URL 입력
+            <input
+              id="projectUrl"
+              defaultValue={inputValue}
+              placeholder="url 주소를 입력해주세요. (예: www.figma.com/abc)"
+              onChange={handleChangeInput}
+            />
+          </label>
+          <div className="buttons">
+            <Button
+              handleClick={handleSubmitURI}
+              usingCase="solid"
+              size="small"
+              className="next"
+            >
+              다음
+            </Button>
+          </div>
+        </form>
+      </ContentsWrapper>
+      {toast.status && (
+        <ToastPopup setToast={setToast} message={toast.message} />
+      )}
+    </>
+  );
 }
+
+const ContentsWrapper = styled.div`
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  padding: 24px;
+
+  .step {
+    margin-bottom: 4px;
+
+    color: #2623fb;
+    font-size: 1.125rem;
+    line-height: 28px;
+    text-align: left;
+    font-weight: 800;
+  }
+
+  .title {
+    margin-bottom: 48px;
+
+    color: #000000;
+    font-size: 1.125rem;
+    line-height: 28px;
+    text-align: left;
+    font-weight: 800;
+  }
+
+  form {
+    width: 100%;
+    height: 100%;
+  }
+
+  input {
+    display: flex;
+    width: 100%;
+    height: 48px;
+    padding: 0px 12px;
+    border-radius: 4px;
+    border: 1px solid #000000;
+    margin-top: 12px;
+    margin-bottom: 12px;
+
+    background-color: #ffffff;
+    font-size: 0.75rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 18px;
+  }
+
+  label {
+    height: 100%;
+
+    color: #000000;
+    font-size: 0.75rem;
+    text-align: left;
+    line-height: 16px;
+    font-weight: 700;
+  }
+
+  Button {
+    width: 100%;
+  }
+
+  .description {
+    display: block;
+
+    color: #868e96;
+    font-size: 1rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 24px;
+  }
+`;
 
 export default NewProject;

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -15,7 +15,7 @@ import getCommonPages from "../../../service/getCommonPages";
 function ProjectVersion() {
   const [isLoaded, setIsLoaded] = useState(false);
   const [toast, setToast] = useState({});
-  const [projectVersion, setProjectVersion] = useState({});
+  const [beforeVersionInfo, setBeforeVersionInfo] = useState({});
 
   const navigate = useNavigate();
 
@@ -29,8 +29,8 @@ function ProjectVersion() {
   }, []);
 
   const handleChange = ev => {
-    setProjectVersion({
-      ...projectVersion,
+    setBeforeVersionInfo({
+      ...beforeVersionInfo,
       [ev.currentTarget.className]: ev.target.value,
     });
   };
@@ -44,12 +44,9 @@ function ProjectVersion() {
       return;
     }
 
-    const lastVersion = getLastVersion(allDates, byDates);
-
-    setProjectVersion(lastVersion);
-
-    const { beforeDate, beforeVersion, afterDate, afterVersion } =
-      projectVersion;
+    const { beforeDate, beforeVersion } = beforeVersionInfo;
+    const lastVersionInfo = getLastVersion(allDates, byDates);
+    const { afterDate, afterVersion } = lastVersionInfo;
 
     if (!(beforeVersion && afterVersion)) {
       setToast({ status: true, message: "선택하지 않은 버전이 존재합니다." });
@@ -71,8 +68,10 @@ function ProjectVersion() {
       return;
     }
 
-    setProject(projectVersion);
+    setProject({ ...beforeVersionInfo, ...lastVersionInfo });
     setIsLoaded(true);
+
+    console.log(project.projectKey, beforeVersion, afterVersion);
 
     const pageList = await getCommonPages(
       project.projectKey,
@@ -139,8 +138,8 @@ function ProjectVersion() {
               <option value="" disabled selected>
                 버전 선택
               </option>
-              {projectVersion.beforeDate &&
-                createOption(byDates[projectVersion.beforeDate])}
+              {beforeVersionInfo.beforeDate &&
+                createOption(byDates[beforeVersionInfo.beforeDate])}
             </select>
             <p className="description">
               지정한 버전 명이 없으면 시간으로 보여요!

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
 import Button from "../shared/Button";
+import Description from "../shared/Description";
 import ToastPopup from "../shared/Toast";
 
 import useProjectStore from "../../../store/project";
@@ -13,11 +14,11 @@ import getLastVersion from "../../../utils/getLastVersion";
 import getCommonPages from "../../../service/getCommonPages";
 
 function ProjectVersion() {
+  const navigate = useNavigate();
+
   const [isLoaded, setIsLoaded] = useState(false);
   const [toast, setToast] = useState({});
   const [beforeVersionInfo, setBeforeVersionInfo] = useState({});
-
-  const navigate = useNavigate();
 
   const { project, setProject, clearProjectVersion } = useProjectStore();
   const { allDates, byDates } = useProjectVersionStore();
@@ -27,6 +28,49 @@ function ProjectVersion() {
     clearProjectVersion();
     clearPages();
   }, []);
+
+  const validateVersions = (
+    beforeVersion,
+    beforeDate,
+    afterDate,
+    afterVersion,
+  ) => {
+    if (!(beforeVersion && afterVersion)) {
+      setToast({ status: true, message: "선택하지 않은 버전이 존재합니다." });
+
+      return;
+    }
+
+    const beforeCreatedAt = new Date(
+      byDates[beforeDate][beforeVersion].createdAt,
+    );
+    const afterCreatedAt = new Date(byDates[afterDate][afterVersion].createdAt);
+
+    if (beforeCreatedAt >= afterCreatedAt) {
+      setToast({
+        status: true,
+        message: "이후 버전은 이전 버전보다 나중이여야 합니다.",
+      });
+
+      return;
+    }
+  };
+
+  const createOption = versions => {
+    const optionList = [];
+
+    for (const versionId in versions) {
+      const versionTitle = versions[versionId].label;
+
+      optionList.push(
+        <option value={versionId} key={versionId}>
+          {versionTitle}
+        </option>,
+      );
+    }
+
+    return optionList;
+  };
 
   const handleChange = ev => {
     setBeforeVersionInfo({
@@ -48,25 +92,7 @@ function ProjectVersion() {
     const lastVersionInfo = getLastVersion(allDates, byDates);
     const { afterDate, afterVersion } = lastVersionInfo;
 
-    if (!(beforeVersion && afterVersion)) {
-      setToast({ status: true, message: "선택하지 않은 버전이 존재합니다." });
-
-      return;
-    }
-
-    const beforeCreatedAt = new Date(
-      byDates[beforeDate][beforeVersion].createdAt,
-    );
-    const afterCreatedAt = new Date(byDates[afterDate][afterVersion].createdAt);
-
-    if (beforeCreatedAt >= afterCreatedAt) {
-      setToast({
-        status: true,
-        message: "이후 버전은 이전 버전보다 나중이여야 합니다.",
-      });
-
-      return;
-    }
+    validateVersions(beforeDate, beforeVersion, afterDate, afterVersion);
 
     setProject({ ...beforeVersionInfo, ...lastVersionInfo });
     setIsLoaded(true);
@@ -79,7 +105,6 @@ function ProjectVersion() {
 
     if (pageList.result === "error") {
       setIsLoaded(false);
-
       setToast({ statue: true, message: pageList.message });
 
       navigate("/new");
@@ -89,22 +114,6 @@ function ProjectVersion() {
     setIsLoaded(false);
 
     navigate("/page");
-  };
-
-  const createOption = versions => {
-    const optionList = [];
-
-    for (const versionId in versions) {
-      const versionTitle = versions[versionId].label;
-
-      optionList.push(
-        <option value={versionId} key={versionId}>
-          {versionTitle}
-        </option>,
-      );
-    }
-
-    return optionList;
   };
 
   return (
@@ -139,9 +148,12 @@ function ProjectVersion() {
               {beforeVersionInfo.beforeDate &&
                 createOption(byDates[beforeVersionInfo.beforeDate])}
             </select>
-            <p className="description">
-              지정한 버전 명이 없으면 시간으로 보여요!
-            </p>
+            <Description
+              className="description"
+              size="medium"
+              align="left"
+              text="지정한 버전 명이 없으면 시간으로 보여요!"
+            />
           </label>
           <div className="buttons">
             <Button
@@ -205,7 +217,7 @@ const ContentsWrapper = styled.div`
     height: 100%;
 
     color: #000000;
-    font-size: 0.75rem;
+    font-size: 0.813rem;
     text-align: left;
     line-height: 16px;
     font-weight: 700;
@@ -224,10 +236,6 @@ const ContentsWrapper = styled.div`
     margin-top: 12px;
 
     color: #868e96;
-    font-size: 0.75rem;
-    line-height: 16px;
-    text-align: left;
-    font-weight: 500;
   }
 
   .buttons {

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -71,8 +71,6 @@ function ProjectVersion() {
     setProject({ ...beforeVersionInfo, ...lastVersionInfo });
     setIsLoaded(true);
 
-    console.log(project.projectKey, beforeVersion, afterVersion);
-
     const pageList = await getCommonPages(
       project.projectKey,
       beforeVersion,

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -4,12 +4,11 @@ import styled from "styled-components";
 
 import Button from "../shared/Button";
 import ToastPopup from "../shared/Toast";
-import Modal from "../shared/Modal";
-import Loading from "../shared/Loading";
 
 import useProjectStore from "../../../store/project";
 import useProjectVersionStore from "../../../store/projectVersion";
 import usePageListStore from "../../../store/projectPage";
+
 import getLastVersion from "../../../utils/getLastVersion";
 import getCommonPages from "../../../service/getCommonPages";
 
@@ -29,10 +28,6 @@ function ProjectVersion() {
     clearPages();
   }, []);
 
-  const lastVersion = getLastVersion(allDates, byDates);
-
-  setProjectVersion(lastVersion);
-
   const handleChange = ev => {
     setProjectVersion({
       ...projectVersion,
@@ -48,6 +43,10 @@ function ProjectVersion() {
 
       return;
     }
+
+    const lastVersion = getLastVersion(allDates, byDates);
+
+    setProjectVersion(lastVersion);
 
     const { beforeDate, beforeVersion, afterDate, afterVersion } =
       projectVersion;
@@ -113,11 +112,6 @@ function ProjectVersion() {
 
   return (
     <>
-      {isLoaded && (
-        <Modal>
-          <Loading />
-        </Modal>
-      )}
       <ContentsWrapper>
         <div>
           <h1 className="step">STEP 02</h1>
@@ -153,11 +147,16 @@ function ProjectVersion() {
             </p>
           </label>
           <div className="buttons">
-            <Button usingCase="line" size="small" className="prev">
+            <Button
+              handleClick={handleClick}
+              usingCase="line"
+              size="small"
+              className="prev"
+            >
               이전
             </Button>
             <Button
-              onClick={handleClick}
+              handleClick={handleClick}
               usingCase="solid"
               size="small"
               className="next"

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -1,5 +1,245 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+
+import Button from "../shared/Button";
+import ToastPopup from "../shared/Toast";
+import Modal from "../shared/Modal";
+import Loading from "../shared/Loading";
+
+import useProjectStore from "../../../store/project";
+import useProjectVersionStore from "../../../store/projectVersion";
+import usePageListStore from "../../../store/projectPage";
+import getLastVersion from "../../../utils/getLastVersion";
+import getCommonPages from "../../../service/getCommonPages";
+
 function ProjectVersion() {
-  return <h1>ProjectVersion</h1>;
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [toast, setToast] = useState({});
+  const [projectVersion, setProjectVersion] = useState({});
+
+  const navigate = useNavigate();
+
+  const { project, setProject, clearProjectVersion } = useProjectStore();
+  const { allDates, byDates } = useProjectVersionStore();
+  const { setPages, clearPages } = usePageListStore();
+
+  useEffect(() => {
+    clearProjectVersion();
+    clearPages();
+  }, []);
+
+  const lastVersion = getLastVersion(allDates, byDates);
+
+  setProjectVersion(lastVersion);
+
+  const handleChange = ev => {
+    setProjectVersion({
+      ...projectVersion,
+      [ev.currentTarget.className]: ev.target.value,
+    });
+  };
+
+  const handleClick = async ev => {
+    ev.preventDefault();
+
+    if (ev.target.classList.contains("prev")) {
+      navigate("/new");
+
+      return;
+    }
+
+    const { beforeDate, beforeVersion, afterDate, afterVersion } =
+      projectVersion;
+
+    if (!(beforeVersion && afterVersion)) {
+      setToast({ status: true, message: "선택하지 않은 버전이 존재합니다." });
+
+      return;
+    }
+
+    const beforeCreatedAt = new Date(
+      byDates[beforeDate][beforeVersion].createdAt,
+    );
+    const afterCreatedAt = new Date(byDates[afterDate][afterVersion].createdAt);
+
+    if (beforeCreatedAt >= afterCreatedAt) {
+      setToast({
+        status: true,
+        message: "이후 버전은 이전 버전보다 나중이여야 합니다.",
+      });
+
+      return;
+    }
+
+    setProject(projectVersion);
+    setIsLoaded(true);
+
+    const pageList = await getCommonPages(
+      project.projectKey,
+      beforeVersion,
+      afterVersion,
+    );
+
+    if (pageList.result === "error") {
+      setIsLoaded(false);
+
+      setToast({ statue: true, message: pageList.message });
+
+      navigate("/new");
+    }
+
+    setPages(pageList.content);
+    setIsLoaded(false);
+
+    navigate("/page");
+  };
+
+  const createOption = versions => {
+    const optionList = [];
+
+    for (const versionId in versions) {
+      const versionTitle = versions[versionId].label;
+
+      optionList.push(
+        <option value={versionId} key={versionId}>
+          {versionTitle}
+        </option>,
+      );
+    }
+
+    return optionList;
+  };
+
+  return (
+    <>
+      {isLoaded && (
+        <Modal>
+          <Loading />
+        </Modal>
+      )}
+      <ContentsWrapper>
+        <div>
+          <h1 className="step">STEP 02</h1>
+          <h1 className="title">
+            현재 버전과 비교할 <br />
+            이전 버전을 선택해 주세요.
+          </h1>
+        </div>
+        <form>
+          <label htmlFor="beforeVersion">
+            이전 버전 선택
+            <select className="beforeDate" onChange={handleChange}>
+              <option value="" disabled selected>
+                날짜 선택
+              </option>
+              {allDates.map(date => {
+                return (
+                  <option key={date} value={date}>
+                    {date}
+                  </option>
+                );
+              })}
+            </select>
+            <select className="beforeVersion" onChange={handleChange}>
+              <option value="" disabled selected>
+                버전 선택
+              </option>
+              {projectVersion.beforeDate &&
+                createOption(byDates[projectVersion.beforeDate])}
+            </select>
+            <p className="description">
+              지정한 버전 명이 없으면 시간으로 보여요!
+            </p>
+          </label>
+          <div className="buttons">
+            <Button usingCase="line" size="small" className="prev">
+              이전
+            </Button>
+            <Button
+              onClick={handleClick}
+              usingCase="solid"
+              size="small"
+              className="next"
+            >
+              다음
+            </Button>
+          </div>
+        </form>
+      </ContentsWrapper>
+      {toast.status && (
+        <ToastPopup setToast={setToast} message={toast.message} />
+      )}
+    </>
+  );
 }
+
+const ContentsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  padding: 24px;
+
+  .step {
+    color: #2623fb;
+    font-size: 1.125rem;
+    line-height: 24px;
+    text-align: left;
+    font-weight: 800;
+  }
+
+  .title {
+    margin-bottom: 48px;
+
+    color: #000000;
+    font-size: 1.125rem;
+    line-height: 24px;
+    text-align: left;
+    font-weight: 800;
+  }
+
+  form {
+    width: 100%;
+    height: 100%;
+  }
+
+  label {
+    height: 100%;
+
+    color: #000000;
+    font-size: 0.75rem;
+    text-align: left;
+    line-height: 16px;
+    font-weight: 700;
+  }
+
+  select {
+    width: 100%;
+    height: 48px;
+    padding: 10px 16px;
+    margin-top: 12px;
+    border: 1.5px solid #000000;
+    border-radius: 4px;
+  }
+
+  .description {
+    margin-top: 12px;
+
+    color: #868e96;
+    font-size: 0.75rem;
+    line-height: 16px;
+    text-align: left;
+    font-weight: 500;
+  }
+
+  .buttons {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    column-gap: 12px;
+    margin-top: 48px;
+  }
+`;
 
 export default ProjectVersion;

--- a/src/ui/components/shared/Description.jsx
+++ b/src/ui/components/shared/Description.jsx
@@ -1,0 +1,60 @@
+import React from "react";
+import styled, { css } from "styled-components";
+import { nanoid } from "nanoid";
+
+const DESCRIPTION_SIZES = {
+  medium: css`
+    --description-font-size: 0.75rem;
+    --description-line-height: 18px;
+  `,
+  large: css`
+    --description-font-size: 0.875rem;
+    --description-line-height: 22px;
+  `,
+};
+
+const TEXT_ALIGN = {
+  center: css`
+    --description-text-align: center;
+  `,
+  left: css`
+    --description-text-align: left;
+  `,
+};
+
+function Description({ className, size, text, align }) {
+  const descriptionSize = DESCRIPTION_SIZES[size];
+  const textAlign = TEXT_ALIGN[align];
+
+  return (
+    <StyledSpan
+      className={className}
+      $descriptionSize={descriptionSize}
+      $textAlign={textAlign}
+    >
+      {text.split("\\n").map(txt => (
+        <React.Fragment key={nanoid(10)}>
+          {txt}
+          <br />
+        </React.Fragment>
+      ))}
+    </StyledSpan>
+  );
+}
+
+const StyledSpan = styled.span`
+  ${props => props.$descriptionSize}
+  ${props => props.$textAlign}
+
+  display: block;
+
+  color: #495057;
+  font-size: var(--description-font-size);
+  text-align: var(--description-text-align);
+  font-family: "Noto Sans KR";
+  font-style: normal;
+  font-weight: 500;
+  line-height: var(--description-line-height);
+`;
+
+export default Description;

--- a/src/ui/components/shared/Toast.jsx
+++ b/src/ui/components/shared/Toast.jsx
@@ -30,16 +30,19 @@ const fadeInUp = keyframes`
 `;
 
 const Toast = styled.div`
-  position: absolute;
+  position: fixed;
   z-index: 2;
   top: 85%;
+  left: 0;
+  right: 0;
+  margin: 0 auto;
 
   display: flex;
   justify-content: center;
   align-items: center;
   width: 80%;
-  height: 70px;
-  border-radius: 20px;
+  height: 44px;
+  border-radius: 8px;
 
   animation: ${fadeInUp} 0.5s ease-in-out;
 
@@ -47,7 +50,7 @@ const Toast = styled.div`
   background-color: #000000;
   color: #ffffff;
   font-family: "Noto Sans KR";
-  font-size: 1.125rem;
+  font-size: 0.75rem;
   text-align: center;
   font-weight: 700;
 `;

--- a/src/utils/getLastVersion.js
+++ b/src/utils/getLastVersion.js
@@ -1,0 +1,21 @@
+const getLastVersion = (allDates, byDates) => {
+  const lastDate = allDates[0];
+  let lastVersionId = null;
+
+  if (byDates[lastDate]) {
+    for (const versionId in byDates[lastDate]) {
+      const version = byDates[lastDate][versionId];
+
+      if (
+        !lastVersionId ||
+        new Date(version.createdAt) > new Date(lastVersionId.createdAt)
+      ) {
+        lastVersionId = versionId;
+      }
+    }
+  }
+
+  return { afterDate: lastDate, afterVersion: lastVersionId };
+};
+
+export default getLastVersion;

--- a/src/utils/isValidFigmaUrl.js
+++ b/src/utils/isValidFigmaUrl.js
@@ -1,0 +1,8 @@
+const isValidFigmaUrl = figmaUrl => {
+  const figmaUrlPattern =
+    /^(?:https:\/\/)?(?:www\.)?figma\.com\/file\/([0-9a-zA-Z]{22,128})(?:\/?([^?]+)?(.*))?$/;
+
+  return figmaUrlPattern.test(figmaUrl);
+};
+
+export default isValidFigmaUrl;

--- a/src/utils/postMessage.js
+++ b/src/utils/postMessage.js
@@ -1,4 +1,4 @@
-const postMessage = (type, content, origin = "*") => {
+const postMessage = (type, content = null, origin = "*") => {
   window.parent.postMessage(
     {
       pluginMessage: {


### PR DESCRIPTION
## Fix (이슈 번호)
closes #10 

<br />

## 해결하려던 문제를 알려주세요!
온보딩 이후, 사용자가 로그인을 성공하면 프로젝트 URL 입력 화면을 띄웁니다.
URL 유효성 검사를 성공하면, Client Storage 내 토큰을 받아 서버에 버전 히스토리 데이터 요청을 보냅니다.
요청을 성공적으로 받으면 버전 선택 페이지로 이동합니다.

<br />

## 어떻게 해결했나요?

### ClientStorage onmessage 오류 관련

`onmessage`가 제대로 실행되지 않아서 토큰값이 계속 같은 값으로 서버에 요청이 가고 있었습니다.
원인은 `figma.ui.onmessage`를 따로 함수로 선언했던 게 원인이었습니다.

`onmessage` 핸들러를 두 번 사용하면 안 되는 주된 이유는 JavaScript에서 이벤트 핸들러를 직접 할당하는 방식 
(element.onEvent = handler)은 기존에 할당된 핸들러를 새로 할당된 핸들러로 덮어쓰기 때문이라는 걸 알게되었습니다.

첫 번째로 할당된 `onmessage` 핸들러는 두 번째 핸들러에 의해 제거됩니다. 
따라서 첫 번째 핸들러에 정의된 로직은 더 이상 실행되지 않습니다.



```javascript
figma.showUI(__html__, { width: 400, height: 540 });

figma.ui.onmessage = async message => {
  console.log(message);

  if (message.type === "SAVE_ACCESS_TOKEN") {
    await figma.clientStorage.setAsync("accessToken", message.content);
  }
};

figma.ui.onmessage = async message => {
  if (message.type === "GET_ACCESS_TOKEN") {
    const accessToken = await figma.clientStorage.getAsync("accessToken");

    figma.ui.postMessage({
      type: "GET_ACCESS_TOKEN",
      content: accessToken,
    });
  }
};
``` 

<br />

그래서 변경한 로직은 아래와 같습니다.
모든 이벤트 처리 로직을 하나의 `onmessage` 핸들러 내에 포함시키고, 
이벤트 타입에 따라 적절한 분기 처리를 하는 방식으로 진행해 중복으로 이벤트가
덮어쓰는 걸 방지하는 로직으로 변경했습니다.

```javascript
figma.showUI(__html__, { width: 400, height: 540 });

figma.ui.onmessage = async message => {
  if (message.type === "SAVE_ACCESS_TOKEN") {
    await figma.clientStorage.setAsync("accessToken", message.content);
  }

  if (message.type === "GET_ACCESS_TOKEN") {
    const accessToken = await figma.clientStorage.getAsync("accessToken");

    figma.ui.postMessage({
      type: "GET_ACCESS_TOKEN",
      content: accessToken,
    });
  }
};
``` 

<br />

[onmessage 중복 관련](https://basketdeveloper.tistory.com/80)
> 더 자세한 공식 문서로 변경하겠습니다.

<br />

## 우려사항이 있나요?(선택사항)

### 패키지 추가 설치 관련
nanoid를 이번에 설치하게 되어서 npm install로 꼭 install 해주세요!

```javascript
npm install
``` 

<br />

### 버전 선택 페이지 추가 작업 관련
현재 버전 선택 페이지 로직으로는 정적 컴포넌트 구현과 버전 정보 유효성 검사만 진행되어 있습니다.

서버에 선택된 버전들에 대해 공통 페이지를 요청하고, 현재 페이지 아이디와 비교하는 로직부터 진행되면 될 것 같습니다.
> 아래에 projectkey, beforeVersion, afterVersion을 찍은 콘솔입니다. 
> 서버에 요청을 보내고, 클라이언트에게 토큰을 요청하는 로직이 추가가 필요합니다.

<img width="659" alt="추가 구현 필요" src="https://github.com/Figci/Figci-Plugin-Client/assets/43771772/f9c94263-6bc7-4bdd-af67-c892bdc7e913">

<br />

### 토스트 팝업 위치 버그 관련
웹 내에서도 왼쪽으로 토스트 팝업이 치우치고 있는데 플러그인에서
해결한 방법 공유 드립니다. 추후 웹 클라이언트 작업 시, 추가로 반영 부탁 드립니다.

> 토스트 팝업이 오른쪽에서 나와서 중앙으로 가는 이유는 left: 50%;와 transform: translateX(-50%);가 함께 사용되어서 발생했습니다.
> margin을 0 auto로 설정하고, left, right를 0으로 설정. position을 fixed로 주어 해결했습니다.
> 사이즈는 웹사이즈로 그대로 사용하시면 됩니다!(폰트, 외관 크기 등)

```javascript
const Toast = styled.div`
  position: fixed;
  z-index: 2;
  top: 85%;
  left: 0;
  right: 0;
  margin: 0 auto;

  display: flex;
  justify-content: center;
  align-items: center;
  width: 80%;
  height: 44px;
  border-radius: 8px;

  animation: ${fadeInUp} 0.5s ease-in-out;

  opacity: 0.8;
  background-color: #000000;
  color: #ffffff;
  font-family: "Noto Sans KR";
  font-size: 0.75rem;
  text-align: center;
  font-weight: 700;
`;

export default ToastPopup;
``` 

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 
### URL 입력 페이지(+ 토스트 팝업)
<img width="402" alt="URL 입력 페이지" src="https://github.com/Figci/Figci-Plugin-Client/assets/43771772/9bffa14b-2efd-4f54-aabc-5c5a8c599371">
<img width="399" alt="토스트팝업" src="https://github.com/Figci/Figci-Plugin-Client/assets/43771772/08f6ba15-2bbe-4039-8d55-73f7351a964f">

### 버전 선택 페이지
<img width="397" alt="버전 선택 페이지" src="https://github.com/Figci/Figci-Plugin-Client/assets/43771772/33bb8b05-66a0-4681-87dd-d6ba7688d228">

<br />
