### PR TITLE
Feat: [PLUG-FE] 버전 선택 페이지

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -53,5 +53,6 @@ module.exports = {
     "guard-for-in": "off",
     "consistent-return": "off",
     "no-shadow": "off",
+    "no-case-declarations": "off",
   },
 };

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "husky": "^9.0.11",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-query": "^3.39.3",
     "react-router-dom": "^6.22.0",
     "styled-components": "^6.1.8",
     "styled-reset": "^4.5.2",

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -42,4 +42,8 @@ figma.ui.onmessage = async message => {
       content: newVersionId,
     });
   }
+
+  if (message.type === "POST_DIFFING_RESULT") {
+    const differences = message.content;
+  }
 };

--- a/src/services/getDiffingResultQuery.js
+++ b/src/services/getDiffingResultQuery.js
@@ -6,9 +6,9 @@ const getDiffingResult = async (
   beforeVersion,
   afterVersion,
   pageId,
+  token,
 ) => {
   const baseURI = import.meta.env.VITE_BACKEND_BASE_API_URI;
-  const token = JSON.parse(localStorage.getItem("FigmaToken")).access_token;
 
   const queryParams = {
     "before-version": beforeVersion,
@@ -38,6 +38,7 @@ const getDiffingResultQuery = (
   beforeVersion,
   afterVersion,
   pageId,
+  token,
 ) => {
   return useQuery(
     `${beforeVersion}-${afterVersion}-${pageId}`,
@@ -47,6 +48,7 @@ const getDiffingResultQuery = (
         beforeVersion,
         afterVersion,
         pageId,
+        token,
       );
 
       return result;

--- a/src/services/getDiffingResultQuery.js
+++ b/src/services/getDiffingResultQuery.js
@@ -1,0 +1,62 @@
+import { useQuery } from "react-query";
+import generateApiUri from "../utils/generateURI";
+
+const getDiffingResult = async (
+  projectKey,
+  beforeVersion,
+  afterVersion,
+  pageId,
+) => {
+  const baseURI = import.meta.env.VITE_BACKEND_BASE_API_URI;
+  const token = JSON.parse(localStorage.getItem("FigmaToken")).access_token;
+
+  const queryParams = {
+    "before-version": beforeVersion,
+    "after-version": afterVersion,
+  };
+
+  const API_URL = generateApiUri(
+    baseURI,
+    `/projects/${projectKey}/pages/${pageId}`,
+    queryParams,
+  );
+
+  const response = await fetch(API_URL, {
+    method: "GET",
+    headers: {
+      authorization: token,
+    },
+  });
+
+  const responseResult = await response.json();
+
+  return responseResult;
+};
+
+const getDiffingResultQuery = (
+  projectKey,
+  beforeVersion,
+  afterVersion,
+  pageId,
+) => {
+  return useQuery(
+    `${beforeVersion}-${afterVersion}-${pageId}`,
+    async () => {
+      const result = await getDiffingResult(
+        projectKey,
+        beforeVersion,
+        afterVersion,
+        pageId,
+      );
+
+      return result;
+    },
+    {
+      cacheTime: 300000,
+      staleTime: Infinity,
+      enabled: !!pageId,
+    },
+  );
+};
+
+export default getDiffingResultQuery;

--- a/src/ui/components/Header/index.jsx
+++ b/src/ui/components/Header/index.jsx
@@ -17,7 +17,7 @@ function Header() {
 const HeadWrapper = styled.div`
   display: flex;
   flex-direction: row;
-  padding: 32px 24px;
+  padding: 24px;
 
   .logo {
     height: 20px;

--- a/src/ui/components/Onboarding/index.jsx
+++ b/src/ui/components/Onboarding/index.jsx
@@ -43,7 +43,7 @@ function Onboarding() {
     if (ev.data.pluginMessage.type === "GET_NEW_VERSION_ID") {
       const newVersionId = ev.data.pluginMessage.content;
 
-      setProject({ afterVersionId: newVersionId });
+      setProject({ afterVersionId: newVersionId.id });
 
       navigate("/version");
     }

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -145,17 +145,22 @@ function ProjectVersion() {
 
   return (
     <>
-      <ContentsWrapper>
-        <div>
-          <h1 className="step">STEP 02</h1>
+      <Wrapper>
+        <ContentHeader>
           <h1 className="title">
             현재 버전과 비교할 <br />
             이전 버전을 선택해 주세요.
           </h1>
-        </div>
-        <form>
+          <Description
+            className="title-description"
+            size="medium"
+            align="left"
+            text="현재 보고 있으신 페이지 기준으로 비교해드려요."
+          />
+        </ContentHeader>
+        <VersionForm>
           <label htmlFor="beforeVersion">
-            이전 버전 선택
+            이전 버전
             <select className="beforeDate" onChange={handleChange}>
               <option value="" disabled selected>
                 날짜 선택
@@ -190,8 +195,8 @@ function ProjectVersion() {
           >
             비교하기
           </Button>
-        </form>
-      </ContentsWrapper>
+        </VersionForm>
+      </Wrapper>
       {toast.status && (
         <ToastPopup setToast={setToast} message={toast.message} />
       )}
@@ -199,36 +204,24 @@ function ProjectVersion() {
   );
 }
 
-const ContentsWrapper = styled.div`
-  display: flex;
-  flex-direction: column;
-  box-sizing: border-box;
-  width: 100%;
-  height: 100%;
+const Wrapper = styled.div`
   padding: 24px;
+`;
 
-  .step {
-    color: #2623fb;
-    font-size: 1.125rem;
-    line-height: 24px;
-    text-align: left;
-    font-weight: 800;
-  }
+const ContentHeader = styled.div`
+  padding: 0 0 48px 0;
 
   .title {
-    margin-bottom: 48px;
-
     color: #000000;
     font-size: 1.125rem;
     line-height: 24px;
     text-align: left;
     font-weight: 800;
   }
+`;
 
-  form {
-    width: 100%;
-    height: 100%;
-  }
+const VersionForm = styled.form`
+  width: 100%;
 
   label {
     height: 100%;
@@ -249,10 +242,19 @@ const ContentsWrapper = styled.div`
     border-radius: 4px;
   }
 
-  .description {
-    margin-top: 12px;
+  .beforeVersion {
+    margin-bottom: 12px;
+  }
 
+  .description {
     color: #868e96;
+  }
+
+  Button {
+    position: fixed;
+
+    width: 355px;
+    bottom: 24px;
   }
 `;
 

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -20,11 +20,10 @@ function ProjectVersion() {
 
   const [toast, setToast] = useState({});
   const [projectInformation, setProjectInformation] = useState({});
-  const [beforeVersionId, setBeforeVersionId] = useState("");
   const [selectedBefore, setSelectedBefore] = useState({});
   const [commonPageId, setCommonPageId] = useState("");
 
-  const { project } = useProjectStore();
+  const { project, setProject } = useProjectStore();
   const { byDates, allDates } = useProjectVersionStore();
   const {
     data: diffingResult,
@@ -33,7 +32,7 @@ function ProjectVersion() {
     error,
   } = getDiffingResultQuery(
     projectInformation.projectKey,
-    beforeVersionId,
+    project.beforeVersionId,
     project.afterVersionId,
     commonPageId,
     projectInformation.accessToken,
@@ -128,7 +127,7 @@ function ProjectVersion() {
       return;
     }
 
-    setBeforeVersionId(selectedBefore.beforeVersion);
+    setProject({ beforeVersionId: selectedBefore.beforeVersion });
     setCommonPageId(currentPageId);
   };
 

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import styled from "styled-components";
 
 import Button from "../shared/Button";
@@ -8,14 +8,132 @@ import ToastPopup from "../shared/Toast";
 import useProjectStore from "../../../store/project";
 import useProjectVersionStore from "../../../store/projectVersion";
 
+import postMessage from "../../../utils/postMessage";
+import createOption from "../../../utils/createOption";
+import isCommonPage from "../../../utils/isCommonPage";
+import getCommonPages from "../../../services/getCommonPages";
+import getDiffingResultQuery from "../../../services/getDiffingResultQuery";
+
+const [GET_CURRENT_PAGE_ID, GET_PROJECT_KEY, GET_ACCESS_TOKEN] = [
+  "GET_CURRENT_PAGE_ID",
+  "GET_PROJECT_KEY",
+  "GET_ACCESS_TOKEN",
+];
+
 function ProjectVersion() {
   const [toast, setToast] = useState({});
+  const [projectInformation, setProjectInformation] = useState({});
+  const [selectedVersion, setSelectedVersion] = useState("");
+  const [commonPageId, setCommonPageId] = useState("");
 
   const { project, setProject, clearProject } = useProjectStore();
   const { byDates, allDates } = useProjectVersionStore();
 
-  const handleChange = () => {};
-  const handleClick = () => {};
+  const {
+    data: diffingResult,
+    isLoading,
+    isError,
+    error,
+  } = getDiffingResultQuery(
+    projectInformation.projectKey,
+    projectInformation.beforeVersion,
+    projectInformation.afterVersion,
+    commonPageId,
+  );
+
+  const handleProjectInformation = ev => {
+    switch (ev.data.pluginMessage.type) {
+      case GET_CURRENT_PAGE_ID:
+        const pageId = ev.data.pluginMessage.content;
+
+        setProjectInformation(currentState => ({ ...currentState, pageId }));
+
+        break;
+
+      case GET_PROJECT_KEY:
+        const projectKey = ev.data.pluginMessage.content;
+
+        setProjectInformation(currentState => ({
+          ...currentState,
+          projectKey,
+        }));
+
+        break;
+
+      case GET_ACCESS_TOKEN:
+        const accessToken = ev.data.pluginMessage.content;
+
+        setProjectInformation(currentState => ({
+          ...currentState,
+          accessToken,
+        }));
+
+        break;
+
+      default:
+        break;
+    }
+  };
+
+  const handleChange = ev => {
+    ev.preventDefault();
+
+    setSelectedVersion({
+      ...selectedVersion,
+      [ev.currentTarget.className]: ev.target.value,
+    });
+  };
+
+  const handleClick = async ev => {
+    ev.preventDefault();
+
+    if (!selectedVersion.beforeVersion) {
+      setToast({ status: true, messaeg: "선택하지 않은 버전이 존재합니다." });
+
+      return;
+    }
+
+    const { beforeVersionId } = selectedVersion;
+    const { afterVersionId } = project;
+    const { projectKey, accessToken } = projectInformation;
+
+    const responseResult = await getCommonPages(
+      projectKey,
+      beforeVersionId,
+      afterVersionId,
+      accessToken,
+    );
+
+    if (responseResult.result === "error") {
+      setToast({ status: true, messaeg: responseResult.message });
+
+      return;
+    }
+
+    const commonPageList = responseResult.content;
+    const currentPageId = projectInformation.pageId;
+
+    if (!isCommonPage(commonPageList, currentPageId)) {
+      setToast({
+        status: true,
+        message: "선택하신 버전에는 현재 페이지가 존재하지 않습니다!",
+      });
+    }
+  };
+
+  useEffect(() => {
+    clearProject();
+
+    postMessage(GET_CURRENT_PAGE_ID);
+    postMessage(GET_PROJECT_KEY);
+    postMessage(GET_ACCESS_TOKEN);
+
+    window.addEventListener("message", handleProjectInformation);
+
+    return () => {
+      window.removeEventListener("message", handleProjectInformation);
+    };
+  }, []);
 
   return (
     <>
@@ -46,6 +164,8 @@ function ProjectVersion() {
               <option value="" disabled selected>
                 버전 선택
               </option>
+              {selectedVersion.beforeDate &&
+                createOption(byDates[selectedVersion.beforeDate])}
             </select>
             <Description
               className="description"
@@ -54,24 +174,14 @@ function ProjectVersion() {
               text="지정한 버전 명이 없으면 시간으로 보여요!"
             />
           </label>
-          <div className="buttons">
-            <Button
-              handleClick={handleClick}
-              usingCase="line"
-              size="small"
-              className="prev"
-            >
-              이전
-            </Button>
-            <Button
-              handleClick={handleClick}
-              usingCase="solid"
-              size="small"
-              className="next"
-            >
-              다음
-            </Button>
-          </div>
+          <Button
+            handleClick={handleClick}
+            usingCase="solid"
+            size="small"
+            className="next"
+          >
+            비교하기
+          </Button>
         </form>
       </ContentsWrapper>
       {toast.status && (

--- a/src/ui/main.jsx
+++ b/src/ui/main.jsx
@@ -1,9 +1,15 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
+import { QueryClient, QueryClientProvider } from "react-query";
+
 import App from "./App";
 
+const queryClient = new QueryClient();
+
 ReactDOM.createRoot(document.getElementById("root")).render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>,
+  <QueryClientProvider client={queryClient}>
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  </QueryClientProvider>,
 );

--- a/src/utils/createOption.jsx
+++ b/src/utils/createOption.jsx
@@ -1,0 +1,17 @@
+const createOption = versions => {
+  const optionList = [];
+
+  for (const versionId in versions) {
+    const versionTitle = versions[versionId].label;
+
+    optionList.push(
+      <option value={versionId} key={versionId}>
+        {versionTitle}
+      </option>,
+    );
+  }
+
+  return optionList;
+};
+
+export default createOption;

--- a/src/utils/isCommonPage.js
+++ b/src/utils/isCommonPage.js
@@ -1,0 +1,11 @@
+const isCommonPage = (commonPageList, targetPageId) => {
+  for (const { pageId } of commonPageList) {
+    if (pageId === targetPageId) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+export default isCommonPage;


### PR DESCRIPTION
## Fix (이슈 번호)
closes #3 

<br />

## 해결하려던 문제를 알려주세요!
1. REST API로부터 해당 프로젝트의 버전들을 모두 가져온 뒤, 드롭박스로 렌더링 합니다.
2. 비교하기 버튼 클릭 시 유저가 선택한 두 버전의 공통페이지를 가져옵니다.
3. 공통페이지중에 현재 유저가 보고있는 페이지의 아이디가 있다면, 해당 페이지 `diffing`을 서버에게 요청합니다.
4. 서버로부터 response받은 `diffingResult`중 `differences`만 sandBox에게 `postMessage`를 통해서 전달합니다.

<br />

## 어떻게 해결했나요?
기존에 리액트 쿼리에 대한 이해가 부족했어서 디버깅하는데 시간이 많이 걸렸습니다.
`useQuery`를 사용하면 `enabled`가 `true`라면 캐싱된 값을 꺼내오거나, 콜백함수를 호출 하는 줄 알았는데,
예상치 못한 사이드 이펙트가 자꾸 발생하여서 찾아본 결과, `enabled`가 `true`더라도 해당 콜백함수에서 사용하는 인자들의 값이
변화가 없다면 콜백함수를 호출하지 않는다는 특성이 있었습니다.
즉,
```js
const getDiffingResultQuery = (
  projectKey,
  beforeVersion,
  afterVersion,
  pageId,
  token,
) => {
  return useQuery(
    `${beforeVersion}-${afterVersion}-${pageId}`,
    async () => {
      const result = await getDiffingResult(
        projectKey,
        beforeVersion,
        afterVersion,
        pageId,
        token,
      );

      return result;
    },
    {
      cacheTime: 300000,
      staleTime: Infinity,
      enabled: !!pageId,
    },
  );
};
```
여기서 enabled가 `true`가 되더라도, `projectKey`, `beforeVersion`, `afterVersion`, `pageId`, `token`들중 값이 하나도 바뀌지 않는다면 리액트 쿼리는 응답하지 않습니다!


<br />

## 우려사항이 있나요?(선택사항)
1. **_플러그인이 웹 서비스에 비해서 컴포넌트의 숫자가 줄어듦에따라 한 컴포넌트에서 수행하는 로직의 양이 많아졌습니다._**
이에따라서 추후 리팩토링에 대해서 같이 고민해보면 좋을 것 같습니다!
2. **_react-query를 설치했습니다. fetch & rebase 후 `npm install` 꼭 해주세요!_**
3. sandBox에 `diffingResult`의 differences를 전달받을 `message type`을 추가했습니다! (`"POST_DIFFING_RESULT"`)

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 

> 리뷰어의 이해를 돕기 위한 모든 이미지, GIF, 링크 등을 첨부해주세요!
> 이번 PR 내 로직, 동작의 이해를 돕는 GIF 파일,
> FRONT 동작 내 스크린샷 등

<br />
