### PR TITLE
Feature: 변경사항 Rect요소 렌더링

### DIFF
--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -2,15 +2,17 @@ figma.showUI(__html__, { width: 400, height: 540 });
 
 const differenceRectangleIdList = [];
 
-figma.on("close", () => {
-  differenceRectangleIdList.forEach(rectangleId => {
-    const rectangleNode = figma.getNodeById(rectangleId);
-
-    rectangleNode.remove();
-  });
-
-  differenceRectangleIdList.length = 0;
-});
+const CONSTANTS = {
+  MODIFIED_FILLS: {
+    type: "SOLID",
+    color: { r: 0.435, g: 0.831, b: 0.505 },
+  },
+  NEW_FILLS: {
+    type: "SOLID",
+    color: { r: 0.435, g: 0.831, b: 0.505 },
+  },
+  RECT_OPACITY: 0.2,
+};
 
 const isOwnProperty = (targetObject, targetProperty) => {
   return Object.prototype.hasOwnProperty.call(targetObject, targetProperty);
@@ -20,7 +22,6 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
   for (const nodeId in differences) {
     if (isOwnProperty(differences, nodeId)) {
       const modifiedNode = differences[nodeId];
-
       const { type, differenceInformation, frameId } = modifiedNode;
       const { x, y, width, height } = modifiedNode.position;
 
@@ -29,39 +30,31 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
       differenceRectangle.resize(width, height);
       differenceRectangle.x = x;
       differenceRectangle.y = y;
+      differenceRectangle.opacity = CONSTANTS.RECT_OPACITY;
 
       switch (type) {
         case "NEW":
-          differenceRectangle.fills = [
-            { type: "SOLID", color: { r: 0.435, g: 0.831, b: 0.505 } },
-          ];
-          differenceRectangle.opacity = 0.2;
+          differenceRectangle.fills = [CONSTANTS.NEW_FILLS];
           differenceRectangle.setPluginData(
             "differenceInformation",
             "선택하신 이전 버전에는 존재하지 않는 노드 입니다!",
           );
 
-          differenceRectangleIdList.push(differenceRectangle.id);
-          modifiedFrames[frameId].isNew = false;
-
           break;
         case "MODIFIED":
-          differenceRectangle.fills = [
-            { type: "SOLID", color: { r: 0.976, g: 0.407, b: 0.329 } },
-          ];
-          differenceRectangle.opacity = 0.2;
+          differenceRectangle.fills = [CONSTANTS.MODIFIED_FILLS];
           differenceRectangle.setPluginData(
             "differenceInformation",
             JSON.stringify(differenceInformation),
           );
 
-          differenceRectangleIdList.push(differenceRectangle.id);
-          modifiedFrames[frameId].isNew = false;
-
           break;
         default:
           break;
       }
+
+      differenceRectangleIdList.push(differenceRectangle.id);
+      modifiedFrames[frameId].isNew = false;
     }
   }
 
@@ -74,10 +67,8 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
         differenceRectangle.resize(width, height);
         differenceRectangle.x = x;
         differenceRectangle.y = y;
-        differenceRectangle.fills = [
-          { type: "SOLID", color: { r: 0.435, g: 0.831, b: 0.505 } },
-        ];
-        differenceRectangle.opacity = 0.2;
+        differenceRectangle.fills = [CONSTANTS.NEW_FILLS];
+        differenceRectangle.opacity = CONSTANTS.RECT_OPACITY;
         differenceRectangle.setPluginData(
           "differenceInformation",
           "선택하신 이전 버전에는 존재하지 않는 프레임 입니다!",
@@ -140,3 +131,13 @@ figma.ui.onmessage = async message => {
     renderDifferenceRectangle(differences, modifiedFrames);
   }
 };
+
+figma.on("close", () => {
+  differenceRectangleIdList.forEach(rectangleId => {
+    const rectangleNode = figma.getNodeById(rectangleId);
+
+    rectangleNode.remove();
+  });
+
+  differenceRectangleIdList.length = 0;
+});

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -37,7 +37,7 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
           differenceRectangle.fills = [CONSTANTS.NEW_FILLS];
           differenceRectangle.setPluginData(
             "differenceInformation",
-            "선택하신 이전 버전에는 존재하지 않는 노드 입니다!",
+            "선택하신 이전 버전에는 존재하지 않는 노드입니다!",
           );
 
           break;
@@ -71,7 +71,7 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
         differenceRectangle.opacity = CONSTANTS.RECT_OPACITY;
         differenceRectangle.setPluginData(
           "differenceInformation",
-          "선택하신 이전 버전에는 존재하지 않는 프레임 입니다!",
+          "선택하신 이전 버전에는 존재하지 않는 프레임입니다!",
         );
 
         differenceRectangleIdList.push(differenceRectangle.id);
@@ -133,8 +133,8 @@ figma.ui.onmessage = async message => {
 };
 
 figma.on("close", () => {
-  differenceRectangleIdList.forEach(rectangleId => {
-    const rectangleNode = figma.getNodeById(rectangleId);
+  differenceRectangleIdList.forEach(rectangleNodeId => {
+    const rectangleNode = figma.getNodeById(rectangleNodeId);
 
     rectangleNode.remove();
   });

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -1,5 +1,94 @@
 figma.showUI(__html__, { width: 400, height: 540 });
 
+const differenceRectangleIdList = [];
+
+figma.on("close", () => {
+  differenceRectangleIdList.forEach(rectangleId => {
+    const rectangleNode = figma.getNodeById(rectangleId);
+
+    rectangleNode.remove();
+  });
+
+  differenceRectangleIdList.length = 0;
+});
+
+const isOwnProperty = (targetObject, targetProperty) => {
+  return Object.prototype.hasOwnProperty.call(targetObject, targetProperty);
+};
+
+const renderDifferenceRectangle = (differences, modifiedFrames) => {
+  for (const nodeId in differences) {
+    if (isOwnProperty(differences, nodeId)) {
+      const modifiedNode = differences[nodeId];
+
+      const { type, differenceInformation, frameId } = modifiedNode;
+      const { x, y, width, height } = modifiedNode.position;
+
+      const differenceRectangle = figma.createRectangle();
+
+      differenceRectangle.resize(width, height);
+      differenceRectangle.x = x;
+      differenceRectangle.y = y;
+
+      switch (type) {
+        case "NEW":
+          differenceRectangle.fills = [
+            { type: "SOLID", color: { r: 0.435, g: 0.831, b: 0.505 } },
+          ];
+          differenceRectangle.opacity = 0.2;
+          differenceRectangle.setPluginData(
+            "differenceInformation",
+            "선택하신 이전 버전에는 존재하지 않는 노드 입니다!",
+          );
+
+          differenceRectangleIdList.push(differenceRectangle.id);
+          modifiedFrames[frameId].isNew = false;
+
+          break;
+        case "MODIFIED":
+          differenceRectangle.fills = [
+            { type: "SOLID", color: { r: 0.976, g: 0.407, b: 0.329 } },
+          ];
+          differenceRectangle.opacity = 0.2;
+          differenceRectangle.setPluginData(
+            "differenceInformation",
+            JSON.stringify(differenceInformation),
+          );
+
+          differenceRectangleIdList.push(differenceRectangle.id);
+          modifiedFrames[frameId].isNew = false;
+
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  for (const frameId in modifiedFrames) {
+    if (isOwnProperty(modifiedFrames, frameId)) {
+      if (modifiedFrames[frameId].isNew) {
+        const differenceRectangle = figma.createRectangle();
+        const { x, y, width, height } = modifiedFrames[frameId];
+
+        differenceRectangle.resize(width, height);
+        differenceRectangle.x = x;
+        differenceRectangle.y = y;
+        differenceRectangle.fills = [
+          { type: "SOLID", color: { r: 0.435, g: 0.831, b: 0.505 } },
+        ];
+        differenceRectangle.opacity = 0.2;
+        differenceRectangle.setPluginData(
+          "differenceInformation",
+          "선택하신 이전 버전에는 존재하지 않는 프레임 입니다!",
+        );
+
+        differenceRectangleIdList.push(differenceRectangle.id);
+      }
+    }
+  }
+};
+
 figma.ui.onmessage = async message => {
   if (message.type === "SAVE_ACCESS_TOKEN") {
     await figma.clientStorage.setAsync("accessToken", message.content);
@@ -44,6 +133,10 @@ figma.ui.onmessage = async message => {
   }
 
   if (message.type === "POST_DIFFING_RESULT") {
-    const differences = message.content;
+    const { differences, modifiedFrames } = message.content;
+
+    differenceRectangleIdList.length = 0;
+
+    renderDifferenceRectangle(differences, modifiedFrames);
   }
 };

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -12,6 +12,7 @@ import useProjectVersionStore from "../../../store/projectVersion";
 import postMessage from "../../../utils/postMessage";
 import createOption from "../../../utils/createOption";
 import isCommonPage from "../../../utils/isCommonPage";
+import isOwnProperty from "../../../utils/isOwnProperty";
 import getCommonPages from "../../../services/getCommonPages";
 import getDiffingResultQuery from "../../../services/getDiffingResultQuery";
 
@@ -46,7 +47,19 @@ function ProjectVersion() {
         return;
       }
 
-      postMessage("POST_DIFFING_RESULT", diffingResult.content.differences);
+      const { differences } = diffingResult.content;
+      const modifiedFrames = {};
+
+      for (const frameId in diffingResult.content.frames) {
+        if (isOwnProperty(diffingResult.content.frames, frameId)) {
+          const frameNode = diffingResult.content.frames[frameId];
+
+          modifiedFrames[frameId] = frameNode.property.absoluteBoundingBox;
+          modifiedFrames[frameId].isNew = true;
+        }
+      }
+
+      postMessage("POST_DIFFING_RESULT", { differences, modifiedFrames });
 
       navigate("/result");
     }

--- a/src/utils/isOwnProperty.js
+++ b/src/utils/isOwnProperty.js
@@ -1,0 +1,5 @@
+const isOwnProperty = (targetObject, targetProperty) => {
+  return Object.prototype.hasOwnProperty.call(targetObject, targetProperty);
+};
+
+export default isOwnProperty;


### PR DESCRIPTION
## Fix (이슈 번호)
closes #16 

<br />

## 해결하려던 문제를 알려주세요!
1. UI로부터 변경사항 노드들을 받아서 `position`을 사용해 해당 위치와 크기에 맞게 변경사항을 렌더 해야 합니다.
- 새로생긴 노드는 초록색, 변경된 노드는 빨간색으로 표시 되어야 합니다.
2. 이때 `rectangle`를 렌더할 때애 각각의 rect들은 본인의 변경사항 데이터를 저장하고 있어야 합니다.
3. 플러그인을 종료할 때 해당 `rectangle`은 삭제되어야 합니다.

<br/>

### 만났던 에러
![image](https://github.com/Figci/Figci-Plugin-Client/assets/48385389/a4ce883a-e74b-4d43-b257-398afbb43167)
→ 플러그인 환경에서 `import`구문을 사용하자 만났던 에러.


<br />

## 어떻게 해결했나요?
1. `Figma Plugin`에서 제공하는 `createRectangle` API를 이용해서 변경사항의 타입에 따라 배경색을 지정해준 뒤,
변경사항의 노드가 있는 위치에 렌더가 되도록 하였습니다. [createRectangle (공식문서)](https://www.figma.com/plugin-docs/api/properties/figma-createrectangle/)

2. Plugin에서 제공하는 `setPluginData`를 이용하여서 변경사항 Rectangle을 create할 시 해당 Rectangle이 갖고 있어야 할 변경사항 정보를 set해주었습니다.
추후 유저가 해당 `Retangle`을 클릭하거나 `Hover`할 시 클릭된 `Rectangle`에 대하여 `getPluginData API`로 처음에 set해준 데이터를 받아와서 `postMessage`로 `UI`에게 전송하는 로직이 필요합니다!
[setPluginData (공식문서)](https://www.figma.com/plugin-docs/api/properties/nodes-setplugindata/)

### 에러 해결을 어떻게 하였나
[figma community에 나와 비슷한 에러가 발생해서 올라온 질문](https://forum.figma.com/t/importing-modules-on-the-figma-plugin/50276/4)
결론은 sandBox환경에서는 외부 모듈을 불러오는 import 구문을 사용 할 수 없다.
이에 따라서 우리가 `plugin`의 `UI`를 `번들링+babel`을 통해 `pure JS`로 바꾼 뒤, 플러그인이 코드를 읽을 수 있게 하는 것처럼
`sandBox`에서 `import`를 비롯한 여러가지 모듈들을 사용 하려면 번들링을 시켜서 한개의 js파일로 만들어 주어야 합니다.
지금은 시간 관계상 번들링을 따로 작업하지는 않았지만, 다음 리팩토링을 할떄 반드시 적용해 보고 싶습니다!

[샌드박스 환경 라이브러리와 번들링 (공식문서)](https://www.figma.com/plugin-docs/libraries-and-bundling/)

<br />

## 우려사항이 있나요?(선택사항)
1. **_`sandbox`에 비즈니스 로직이 추가되었습니다!_**
2. **_`hasOwnProperty`를 사용할 때 변수명이 길어짐에 따라 가독성이 현저히 떨어져서 `isOwnProperty`로 모듈화를 시켰습니다!_**
- 사용법
```js
import isOwnproperty from "../utils";

// `B`라는 프로퍼티가 `A`라는 객체의 순수한 프로퍼티인지 확인하고 싶다면
isOwnProperty(A, B); // true or false
```

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 
![2024-02-20 21 47 42](https://github.com/Figci/Figci-Plugin-Client/assets/48385389/d156ba09-c219-4d22-8b3f-3d9f1d2a19fa)
→ 새로생긴 요소이므로 초록색으로 렌더하고, 플러그인을 종료하자 변경사항 `Rectangle`이 사라지는 모습

<br />
