### PR TITLE
Feat: Difference 컴포넌트 렌더링 구현

### DIFF
--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -1,0 +1,7 @@
+const CONFIG = {
+  DELAY_TIME_POLLING: 2000,
+  NEW_NODE: "이전 버전엔 없던 새로운 요소이에요!",
+  NEW_FRAME: "이전 버전엔 없던 새로운 프레임이에요!",
+};
+
+export default CONFIG;

--- a/src/constants/timeConstants.js
+++ b/src/constants/timeConstants.js
@@ -1,5 +1,0 @@
-const DELAY_TIME = {
-  POLLING: 2000,
-};
-
-export default DELAY_TIME;

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -5,33 +5,14 @@ import styled from "styled-components";
 import Description from "../shared/Description";
 import Button from "../shared/Button";
 
+import processDifferences from "../../../utils/processDifferences";
+
 function Difference() {
   const navigate = useNavigate();
   const [displayText, setDisplayText] = useState({
     text: "변경사항을 선택해주세요.",
     className: "default",
   });
-
-  const processDifferences = ({ differenceInformation }) => {
-    const NEW_NODE = "선택하신 이전 버전에는 존재하지 않는 노드입니다!";
-    const NEW_FRAME = "선택하신 이전 버전에는 존재하지 않는 프레임입니다!";
-
-    if (
-      differenceInformation === NEW_NODE ||
-      differenceInformation === NEW_FRAME
-    ) {
-      return { text: differenceInformation, className: "active" };
-    }
-
-    const modifiedInformation = JSON.parse(differenceInformation);
-    let differenceTexts = "";
-
-    for (const key in modifiedInformation) {
-      differenceTexts += `${key}(변경)\n${modifiedInformation[key]}\n`;
-    }
-
-    return { text: differenceTexts, className: "active" };
-  };
 
   const handleRectangleClick = ev => {
     if (ev.data.pluginMessage.type === "RENDER_DIFFERENCE_INFORMATION") {

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -12,19 +12,38 @@ function Difference() {
     className: "default",
   });
 
-  const handleRectangleClick = ev => {
-    ev.preventDefault();
+  const processDifferences = ({ differenceInformation }) => {
+    const NEW_NODE = "선택하신 이전 버전에는 존재하지 않는 노드입니다!";
+    const NEW_FRAME = "선택하신 이전 버전에는 존재하지 않는 프레임입니다!";
 
+    if (
+      differenceInformation === NEW_NODE ||
+      differenceInformation === NEW_FRAME
+    ) {
+      return { text: differenceInformation, className: "active" };
+    }
+
+    const modifiedInformation = JSON.parse(differenceInformation);
+    let differenceTexts = "";
+
+    for (const key in modifiedInformation) {
+      differenceTexts += `${key}(변경)\n${modifiedInformation[key]}\n`;
+    }
+
+    return { text: differenceTexts, className: "active" };
+  };
+
+  const handleRectangleClick = ev => {
     if (ev.data.pluginMessage.type === "RENDER_DIFFERENCE_INFORMATION") {
       const differences = ev.data.pluginMessage.content;
 
-      setDisplayText(differences);
+      const differencesInformation = processDifferences(differences);
+
+      setDisplayText(differencesInformation);
     }
   };
 
   useEffect(() => {
-    postMessage("RENDER_DIFFERENCE_INFORMATION");
-
     window.addEventListener("message", handleRectangleClick);
 
     return () => {
@@ -82,8 +101,6 @@ const Content = styled.div`
     overflow-y: auto;
     display: flex;
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
     width: 100%;
     height: 280px;
     margin-bottom: 24px;
@@ -96,6 +113,9 @@ const Content = styled.div`
   }
 
   .difference-area.default {
+    align-items: center;
+    justify-content: center;
+
     color: #868e96;
     text-align: center;
   }
@@ -103,6 +123,8 @@ const Content = styled.div`
   .difference-area.active {
     color: #000000;
     text-align: left;
+
+    white-space: pre;
   }
 
   .description {

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -1,5 +1,119 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+
+import Description from "../shared/Description";
+import Button from "../shared/Button";
+
 function Difference() {
-  return <h1>Difference</h1>;
+  const navigate = useNavigate();
+  const [displayText, setDisplayText] = useState({
+    text: "변경사항을 선택해주세요.",
+    className: "default",
+  });
+
+  const handleRectangleClick = ev => {
+    ev.preventDefault();
+
+    if (ev.data.pluginMessage.type === "RENDER_DIFFERENCE_INFORMATION") {
+      const differences = ev.data.pluginMessage.content;
+
+      setDisplayText(differences);
+    }
+  };
+
+  useEffect(() => {
+    postMessage("RENDER_DIFFERENCE_INFORMATION");
+
+    window.addEventListener("message", handleRectangleClick);
+
+    return () => {
+      window.removeEventListener("message", handleRectangleClick);
+    };
+  }, []);
+
+  return (
+    <Content>
+      <h1 className="title">디자인 변경 사항을 확인해 보세요! 👀</h1>
+      <Description
+        className="description"
+        size="large"
+        align="left"
+        text="빨강/초록 영역을 선택하시면, 해당 영역에 있는 변경사항을\n자세하게 살펴볼 수 있어요."
+      />
+      <div className={`difference-area ${displayText.className}`}>
+        {displayText.text}
+      </div>
+      <div className="button">
+        <Button
+          className="re-version"
+          size="medium"
+          usingCase="line"
+          handleClick={ev => {
+            ev.preventDefault();
+
+            navigate("/version");
+          }}
+        >
+          버전 재선택
+        </Button>
+      </div>
+    </Content>
+  );
 }
+
+const Content = styled.div`
+  box-sizing: border-box;
+  width: 100%;
+  padding: 0px 24px;
+
+  .title {
+    margin-bottom: 4px;
+
+    color: #000000;
+    font-size: 1.125rem;
+    line-height: 24px;
+    text-align: left;
+    font-weight: 800;
+  }
+
+  .difference-area {
+    box-sizing: border-box;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    height: 280px;
+    margin-bottom: 24px;
+    padding: 16px;
+    border-radius: 8px;
+
+    background-color: #f1f3f5;
+    font-size: 0.875rem;
+    line-height: 22px;
+  }
+
+  .difference-area.default {
+    color: #868e96;
+    text-align: center;
+  }
+
+  .difference-area.active {
+    color: #000000;
+    text-align: left;
+  }
+
+  .description {
+    color: #868e96;
+    margin-bottom: 24px;
+  }
+
+  .button {
+    position: fixed;
+    bottom: 24px;
+  }
+`;
 
 export default Difference;

--- a/src/ui/components/Login/index.jsx
+++ b/src/ui/components/Login/index.jsx
@@ -8,7 +8,7 @@ import Button from "../shared/Button";
 import figciLogo from "../../../../assets/logo_figci.png";
 import { openAuth, getToken } from "../../../services/getAuth";
 import postMessage from "../../../utils/postMessage";
-import DELAY_TIME from "../../../constants/timeConstants";
+import CONFIG from "../../../constants/config";
 
 function Login() {
   const navigate = useNavigate();
@@ -29,7 +29,7 @@ function Login() {
         setAccessToken(accessToken);
         clearInterval(pollingId);
       }
-    }, DELAY_TIME.POLLING);
+    }, CONFIG.DELAY_TIME_POLLING);
   };
 
   useEffect(() => {

--- a/src/utils/processDifferences.js
+++ b/src/utils/processDifferences.js
@@ -1,0 +1,22 @@
+const NEW_NODE = "이전 버전엔 없던 새로운 요소이에요!";
+const NEW_FRAME = "이전 버전엔 없던 새로운 프레임이에요!";
+
+const processDifferences = ({ differenceInformation }) => {
+  if (
+    differenceInformation === NEW_NODE ||
+    differenceInformation === NEW_FRAME
+  ) {
+    return { text: differenceInformation, className: "active" };
+  }
+
+  const modifiedInformation = JSON.parse(differenceInformation);
+  let differenceTexts = "";
+
+  for (const key in modifiedInformation) {
+    differenceTexts += `${key}(변경)\n${modifiedInformation[key]}\n`;
+  }
+
+  return { text: differenceTexts, className: "active" };
+};
+
+export default processDifferences;

--- a/src/utils/processDifferences.js
+++ b/src/utils/processDifferences.js
@@ -1,10 +1,9 @@
-const NEW_NODE = "이전 버전엔 없던 새로운 요소이에요!";
-const NEW_FRAME = "이전 버전엔 없던 새로운 프레임이에요!";
+import CONFIG from "../constants/config";
 
 const processDifferences = ({ differenceInformation }) => {
   if (
-    differenceInformation === NEW_NODE ||
-    differenceInformation === NEW_FRAME
+    differenceInformation === CONFIG.NEW_NODE ||
+    differenceInformation === CONFIG.NEW_FRAME
   ) {
     return { text: differenceInformation, className: "active" };
   }


### PR DESCRIPTION
## Fix (이슈 번호)
closes #4

<br />

## 해결하려던 문제를 알려주세요!
서버로부터 받은 결과를 수신하여 강조 노드를 렌더할 정보를 샌드박스에게 postMessage로 전달해야 합니다.
버전 재선택 버튼을 클릭할 시 새로운 버전을 선택할 수 있는 페이지로 이동하고, 노드의 변경사항을 텍스트를 표시할 수 있는 영역을 보여줍니다.

강조 노드를 클릭하면, 노드에 추가된 클릭 이벤트가 발생해 서버에서 전달받은 메세지를 플러그인 UI 텍스트 영역으로 보여줍니다.
다른 노드를 클릭하거나 클릭하지 않으면 선택된 영역이 없어요 메세지를 출력합니다.

<br />

## 어떻게 해결했나요?

### 변경사항 정보를 담은 사각형을 피그마에서 클릭했을 시
"RENDER_DIFFERENCE_INFORMATION"이라는 플러그인 메세지 타입이 맞다면, 
변수에 해당 변경사항 데이터 정보를 담아 화면에 보여줍니다.

```javascript
const handleRectangleClick = ev => {
    if (ev.data.pluginMessage.type === "RENDER_DIFFERENCE_INFORMATION") {
      const differences = ev.data.pluginMessage.content;

      const differencesInformation = processDifferences(differences);

      setDisplayText(differencesInformation);
    }
  };

  useEffect(() => {
    window.addEventListener("message", handleRectangleClick);

    return () => {
      window.removeEventListener("message", handleRectangleClick);
    };
  }, []);
``` 

<br />

### 초기 사용 시
초기 상태값으로 "변경사항을 선택해주세요"라는 텍스트로 사용자가 변경사항 사각형을 
선택할 수 있도록 가이드 문구를 담아 상태값을 `className`과 함께 주었습니다.

```javascript
  const [displayText, setDisplayText] = useState({
    text: "변경사항을 선택해주세요.",
    className: "default",
  });
```

<br />
 
### 조건부 렌더링(클릭 이벤트가 있을 때/없을 때)
클래스를 나누어 클릭 이벤트가 있을 때와 없을 때를 나누어 렌더링 될 수 있도록 조건부 렌더링으로 설정했습니다.
```javascript
    <div className={`difference-area ${displayText.className}`}>
      {displayText.text}
    </div>

  .difference-area.default {
    align-items: center;
    justify-content: center;

    color: #868e96;
    text-align: center;
  }

  .difference-area.active {
    color: #000000;
    text-align: left;

    white-space: pre;
  }
``` 

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />
