### PR TITLE
Feature: sandBox환경 Rectangle 상호작용

### DIFF
--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -12,6 +12,7 @@ const CONSTANTS = {
     color: { r: 0.435, g: 0.831, b: 0.505 },
   },
   RECT_OPACITY: 0.2,
+  MIN_SIZE_VALUE: 1,
 };
 
 const isOwnProperty = (targetObject, targetProperty) => {
@@ -28,7 +29,10 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
       const differenceRectangle = figma.createRectangle();
 
       differenceRectangle.name = "Difference Rectangle Node";
-      differenceRectangle.resize(width || 1, height || 1);
+      differenceRectangle.resize(
+        width || CONSTANTS.MIN_SIZE_VALUE,
+        height || CONSTANTS.MIN_SIZE_VALUE,
+      );
       differenceRectangle.x = x;
       differenceRectangle.y = y;
       differenceRectangle.opacity = CONSTANTS.RECT_OPACITY;
@@ -38,7 +42,7 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
           differenceRectangle.fills = [CONSTANTS.NEW_FILLS];
           differenceRectangle.setPluginData(
             "differenceInformation",
-            "이전 버전엔 없던 새로운 요소이에요!",
+            "이전 버전엔 없던 새로운 요소에요!",
           );
 
           break;
@@ -81,7 +85,7 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
   }
 };
 
-const clearRectangeNode = () => {
+const clearRectangleNode = () => {
   differenceRectangleIdList.forEach(rectangleNodeId => {
     const rectangleNode = figma.getNodeById(rectangleNodeId);
 
@@ -137,7 +141,7 @@ figma.ui.onmessage = async message => {
   if (message.type === "POST_DIFFING_RESULT") {
     const { differences, modifiedFrames } = message.content;
 
-    clearRectangeNode();
+    clearRectangleNode();
 
     renderDifferenceRectangle(differences, modifiedFrames);
   }
@@ -165,7 +169,7 @@ figma.on("selectionchange", () => {
 figma.on("currentpagechange", () => {
   const currentPageId = figma.currentPage.id;
 
-  clearRectangeNode();
+  clearRectangleNode();
 
   figma.ui.postMessage({
     type: "CHANGED_CURRENT_PAGE_ID",
@@ -174,7 +178,7 @@ figma.on("currentpagechange", () => {
 });
 
 figma.on("close", () => {
-  clearRectangeNode();
+  clearRectangleNode();
 
   figma.closePlugin();
 });

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -27,6 +27,7 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
 
       const differenceRectangle = figma.createRectangle();
 
+      differenceRectangle.name = "Difference Rectangle Node";
       differenceRectangle.resize(width || 1, height || 1);
       differenceRectangle.x = x;
       differenceRectangle.y = y;
@@ -136,7 +137,7 @@ figma.ui.onmessage = async message => {
   if (message.type === "POST_DIFFING_RESULT") {
     const { differences, modifiedFrames } = message.content;
 
-    differenceRectangleIdList.length = 0;
+    clearRectangeNode();
 
     renderDifferenceRectangle(differences, modifiedFrames);
   }

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -129,7 +129,7 @@ figma.ui.onmessage = async message => {
 
   if (message.type === "GET_NEW_VERSION_ID") {
     const newVersionId = await figma.saveVersionHistoryAsync(
-      new Date().toISOString().split("T").join(" "),
+      new Date().toISOString().split("T")[1],
     );
 
     figma.ui.postMessage({

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -105,7 +105,7 @@ function ProjectVersion() {
     ev.preventDefault();
 
     if (!selectedBefore.beforeVersion) {
-      setToast({ status: true, messaeg: "선택하지 않은 버전이 존재합니다." });
+      setToast({ status: true, message: "선택하지 않은 버전이 존재합니다." });
 
       return;
     }
@@ -123,7 +123,7 @@ function ProjectVersion() {
     );
 
     if (responseResult.result === "error") {
-      setToast({ status: true, messaeg: responseResult.message });
+      setToast({ status: true, message: responseResult.message });
 
       return;
     }


### PR DESCRIPTION
## Fix (이슈 번호)
closes #17 
closes #6 

<br />

## 해결하려던 문제를 알려주세요!
1. 유저가 rect를 클릭한것을 인식하고, 해당 rect가 갖고있는 데이터를 가져와야 합니다.
2. 클릭한 변경사항노드에 대하여 데이터를 가져 온 뒤, 해당 데이터의 내용을 Difference컴포넌트에게 전달해주어야 합니다.
(`"RENDER_DIFFERENCE_INFORMATION"`)
3. 페이지가 변경됨에 따라 변경 된 페이지의 아이디를 Difference컴포넌트에게 전달해주어야 합니다.
(`"CHANGED_CURRENT_PAGE_ID"`)
4. 유저가 보고있는 페이지가 바뀌거나,
동일한 페이지에서 다른 버전을 선택 하여 새로운 DiffingResult가 도출되서 다시 render해야하거나,
플러그인이 종료될 경우
화면에 그려져 있던 변경사항 노드들은 모두 삭제가 되어야 합니다.

<br />

## 어떻게 해결했나요?
1. 처음에 변경사항 노드들을 렌더해줄 때 `setPluginData` API를 이용하여 각 변경사항 정보들을 metadata로 넣어준 것을 이용하여
노드가 클릭되었을 때 `getPluginData`로 해당 내용을 가져왔습니다.
- **_어떻게 노드가 클릭된 것을 감지할 수 있나요?_**
> figma에서 제공하는 `selectionchange`라는 이벤트를 통해
현재 페이지 내에서 선택된 노드의 정보를 가져옴으로써 변경사항 노드가 클릭 됬다는 것을 감지 할 수 있었습니다.

<br/>

2. sandbox와 ui가 주고받는 방법인 `postMessage`를 통해 "RENDER_DIFFERENCE_INFORMATION"이라는 type으로 ui에게 메세지를 전달하였습니다.

<br/>

3. figma plugin의 `changecurrentpage` 이벤트를 이용하면 현재 프로젝트 내에 유저가 보고있는 페이지가 변경됨을 감지할 수 있습니다.
이에 따라 페이지가 변경 될 시 해당 페이지의 아이디를 받아올 수 있도록 로직을 작성했습니다.

<br />

4. 변경사항노드가 생성 될 시 해당 노드의 id값들을 `differenceRectangleIdList`라는 배열에 추가해줍니다.
따라서 변경사항노드들을 삭제하는 경우에는 해당 `differenceRectangleIdList`를 순회하며, 각 id들에 대하여 getNodeById를 사용하여 노드를 가져온 뒤, remove메서드를 실행함으로써, 변경사항노드들을 지울 수 있었습니다.
추가적으로 변경사항노드들이 삭제되면 `differenceRectangleIdList`들 또한 빈 배열로 초기화 해줍니다.

### • 마주했던 어려움
1. **_유저가 페이지를 변경하기 위해 페이지 노드를 클릭할 시 `changecurrentpage`이벤트와 `selectionchange`이벤트가
둘 다 호출되기 때문에 이를 수정해야 했습니다._**
유저가 페이지를 눌렀을 경우에는 `selectionchange`의 이벤트가 발생하지 않았으면 했습니다.
하지만 이를 막을 수는 없었고, 결국 `pageId`가 클릭 되었을 때는 `selectionchange`의 콜백함수에서 조건을 걸어 `early return`처리를 해주어서 해결 했습니다.

<br/>

2. 변경사항 렌더 시 `width`또는 `height`가 0인 요소들이 존재했습니다.
Figma에서 `line`이라는 요소를 그리게 되면 해당 요소들은 Figma에 그려지긴 하지만, 트리에 저장되는 정보에는
`width` 또는 `height`가 `0`으로 저장되는 경우가 있었어서, 해당 요소가 변경사항이 있을 경우 변경사항 요소를 렌더해주어야 하는데,
`height`값이 `0`이기 때문에 `createRectangle`을 해주는 과정에서 에러가 발생하였습니다.
따라서 값이 0일 경우에는 `||` 를 활용하여 1이 값으로 들어가게끔 해서 에러를 해결했습니다.

```js
 const differenceRectangle = figma.createRectangle();

differenceRectangle.name = "Difference Rectangle Node";
differenceRectangle.resize(width || 1, height || 1);
differenceRectangle.x = x;
differenceRectangle.y = y;
differenceRectangle.opacity = CONSTANTS.RECT_OPACITY;
```

<br/>

<img width="501" alt="image" src="https://github.com/Figci/Figci-Plugin-Client/assets/48385389/d94fb523-2093-42b6-b4e3-d365ecefa07e">
<br/>
→ figma에서는 그려지지만, height값이 0으로 표시되는 line으로 그린 요소

<br/>
<br/>

## 우려사항이 있나요?(선택사항)
1. sandbox내부에 변경사항요소를 삭제하는 로직을 `clearRectangeNode`라는 함수로 따로 분리하여, 호출해서 사용할 수 있게 하였습니다.
2. 변경사항요소가 렌더 될때 해당 Rectangle 노드의 이름을 `Difference Rectangle Node`로 수정하였습니다.

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 
<img width="834" alt="image" src="https://github.com/Figci/Figci-Plugin-Client/assets/48385389/909b6324-1860-4982-ae51-3431a92492bd">

→ 변경된 `RectangleNode` 이름
