### PR TITLE
Feature: 변경 페이지 - 페이지 변경시 쿼리 호출 상태 관리

### DIFF
--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -163,6 +163,11 @@ figma.on("selectionchange", () => {
       type: "RENDER_DIFFERENCE_INFORMATION",
       content: { differenceInformation },
     });
+  } else {
+    figma.ui.postMessage({
+      type: "RENDER_DIFFERENCE_INFORMATION",
+      content: "UNCHANGED_NODE",
+    });
   }
 });
 

--- a/src/store/projectPage.js
+++ b/src/store/projectPage.js
@@ -1,0 +1,44 @@
+import { create } from "zustand";
+
+const pageStore = set => {
+  return {
+    byPageIds: {},
+    allPageIds: [],
+    setPages: pageList => {
+      const pageIds = [];
+
+      pageList.forEach(page => {
+        const { pageId, pageName } = page;
+
+        pageIds.push(pageId);
+
+        set(state => {
+          state.byPageIds = {
+            ...state.byPageIds,
+            [pageId]: pageName,
+          };
+
+          return state;
+        });
+      });
+
+      set(state => {
+        state.allPageIds = pageIds;
+
+        return state;
+      });
+    },
+    clearPages: () => {
+      set(state => {
+        state.byPageIds = {};
+        state.allPageIds = [];
+
+        return state;
+      });
+    },
+  };
+};
+
+const usePageListStore = create(pageStore);
+
+export default usePageListStore;

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import { nanoid } from "nanoid";
 
-import { useNavigate } from "react-router-dom";
 import Description from "../shared/Description";
 import Button from "../shared/Button";
 import ToastPopup from "../shared/Toast";
@@ -13,9 +12,9 @@ import Popup from "../shared/Popup";
 import usePageListStore from "../../../store/projectPage";
 import useProjectStore from "../../../store/project";
 
+import getDiffingResultQuery from "../../../services/getDiffingResultQuery";
 import isOwnProperty from "../../../utils/isOwnProperty";
 import postMessage from "../../../utils/postMessage";
-import getDiffingResultQuery from "../../../services/getDiffingResultQuery";
 import processDifferences from "../../../utils/processDifferences";
 
 function Difference() {
@@ -23,6 +22,12 @@ function Difference() {
   const [pageId, setPageId] = useState("");
   const [isOpenedPopup, setIsOpenedPopup] = useState(false);
   const [projectStatus, setProjectStatus] = useState({});
+  const [displayText, setDisplayText] = useState({
+    titleOfChanges: null,
+    detailOfChanges: ["변경사항을 선택해주세요."],
+    className: "default",
+  });
+
   const { allPageIds } = usePageListStore();
   const { project } = useProjectStore();
 
@@ -33,12 +38,6 @@ function Difference() {
     pageId,
     projectStatus.accessToken,
   );
-  const navigate = useNavigate();
-  const [displayText, setDisplayText] = useState({
-    titleOfChanges: null,
-    detailOfChanges: ["변경사항을 선택해주세요."],
-    className: "default",
-  });
 
   const handleRectangleClick = ev => {
     if (ev.data.pluginMessage.type === "RENDER_DIFFERENCE_INFORMATION") {
@@ -71,8 +70,8 @@ function Difference() {
 
     if (ev.data.pluginMessage.type === "CHANGED_CURRENT_PAGE_ID") {
       const pageId = ev.data.pluginMessage.content;
-
       const isComparablePage = allPageIds.includes(pageId);
+
       if (!isComparablePage) {
         setToast({
           status: true,
@@ -121,10 +120,10 @@ function Difference() {
   }, [diffingResult]);
 
   useEffect(() => {
-    window.addEventListener("message", handleRectangleClick);
-
     postMessage("GET_PROJECT_KEY");
     postMessage("GET_ACCESS_TOKEN");
+
+    window.addEventListener("message", handleRectangleClick);
 
     return () => {
       window.removeEventListener("message", handleRectangleClick);
@@ -175,6 +174,7 @@ function Difference() {
             usingCase="line"
             handleClick={ev => {
               ev.preventDefault();
+
               setPageId("");
 
               setIsOpenedPopup(true);

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -2,9 +2,13 @@ import React, { useState, useEffect } from "react";
 import styled from "styled-components";
 import { nanoid } from "nanoid";
 
+import { useNavigate } from "react-router-dom";
 import Description from "../shared/Description";
 import Button from "../shared/Button";
 import ToastPopup from "../shared/Toast";
+import Loading from "../shared/Loading";
+import Modal from "../shared/Modal";
+import Popup from "../shared/Popup";
 
 import usePageListStore from "../../../store/projectPage";
 import useProjectStore from "../../../store/project";
@@ -22,7 +26,7 @@ function Difference() {
   const { allPageIds } = usePageListStore();
   const { project } = useProjectStore();
 
-  const { data: diffingResult } = getDiffingResultQuery(
+  const { data: diffingResult, isLoading } = getDiffingResultQuery(
     projectStatus.projectKey,
     project.beforeVersionId,
     project.afterVersionId,
@@ -37,14 +41,13 @@ function Difference() {
   });
 
   const handleRectangleClick = ev => {
-    setIsLoading(true);
-
     if (ev.data.pluginMessage.type === "RENDER_DIFFERENCE_INFORMATION") {
       const differences = ev.data.pluginMessage.content;
 
       if (differences === "UNCHANGED_NODE") {
         setDisplayText({
-          text: "변경사항을 선택해주세요.",
+          titleOfChanges: null,
+          detailOfChanges: ["변경사항을 선택해주세요."],
           className: "default",
         });
       } else {
@@ -81,13 +84,12 @@ function Difference() {
 
       setPageId(pageId);
     }
-
-    setIsLoading(false);
   };
 
   useEffect(() => {
     setDisplayText({
-      text: "변경사항을 선택해주세요.",
+      titleOfChanges: null,
+      detailOfChanges: ["변경사항을 선택해주세요."],
       className: "default",
     });
   }, [pageId]);
@@ -175,7 +177,7 @@ function Difference() {
               ev.preventDefault();
               setPageId("");
 
-              navigate("/version");
+              setIsOpenedPopup(true);
             }}
           >
             버전 재선택

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -135,6 +135,7 @@ function ProjectVersion() {
     );
 
     setPages(responseResult.content);
+
     if (responseResult.result === "error") {
       setToast({ status: true, message: responseResult.message });
 

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -10,6 +10,7 @@ import Loading from "../shared/Loading";
 
 import useProjectStore from "../../../store/project";
 import useProjectVersionStore from "../../../store/projectVersion";
+import usePageListStore from "../../../store/projectPage";
 
 import postMessage from "../../../utils/postMessage";
 import createOption from "../../../utils/createOption";
@@ -29,6 +30,8 @@ function ProjectVersion() {
 
   const { project, setProject } = useProjectStore();
   const { byDates, allDates } = useProjectVersionStore();
+  const { setPages } = usePageListStore();
+
   const {
     data: diffingResult,
     isLoading,
@@ -131,6 +134,7 @@ function ProjectVersion() {
       projectInformation.accessToken,
     );
 
+    setPages(responseResult.content);
     if (responseResult.result === "error") {
       setToast({ status: true, message: responseResult.message });
 


### PR DESCRIPTION
## Fix (이슈 번호)

closes #19

<br />

## 해결하려던 문제를 알려주세요!
1. 변경 영역 노드가 아닌 다른 노드 클릭시 UI상에 보여질 기본값 설정 -  `변경 노드를 선택해주세요` 
2. 페이지 이동 시 비교 할 수 `없는` 페이지 - 에러 메세지와 함께 토스트 노출
3. 페이지 이동 시 비교 할 수 `있는` 페이지 - 비교 결과 쿼리 요청 후 렌더링
4. 다른 페이지에서 현재 페이지 복귀 시 쿼리 요청하지 않고 캐싱된 결과 빠르게 렌더링
5. `다른 버전 비교` 클릭시 - 변경 Text 리셋 & 변경 Rect 삭제 ⇒ 다른 버전 쿼리 요청 후 렌더링

<br />

## 어떻게 해결했나요?

### 1. 변경 영역 노드가 아닌 다른 노드 클릭시 UI상에 보여질 기본값 설정 
  - 샌드박스에서 노드 선택 이벤트 발생 시 선택한 노드 id가 Figci 가 렌더한 노드 Id와
   일치하지 않는 경우 content 메세지에 `UNCHANGE_NODE`를 담아서 UI에게 반환합니다.
```
...
// 선택한 노드가 differenceRectangleIdList 와 일치하는 경우
...
} else {
    figma.ui.postMessage({
      type: "RENDER_DIFFERENCE_INFORMATION",
      content: "UNCHANGED_NODE",
    });
  }
```
### 2. 다른 페이지에서 현재 페이지 복귀 시 쿼리 요청하지 않고 캐싱된 결과 빠르게 렌더링
  - 변경된 페이지 id가 비교 가능한 페이지(두 버전 공통 존재 페이지)가 아닌 경우 토스트 노출
```
const isComparablePage = allPageIds.includes(pageId);

if (!isComparablePage) {
  setToast({
    status: true,
    message: "이전 버전에 존재하지 않는 페이지 입니다.",
  });

  return;
}

setPageId(pageId);
```
  - 변경된 페이지 id가 비교 가능한 페이지(두 버전 공통 존재 페이지)인 경우에만 pageId 상태 Set
  - 리액트 쿼리를 호출하는 인자 4개는 변경되지 않도록 하고 pageId 가 변경될 경우에만 쿼리 호출됨
```
  const { data: diffingResult, isLoading } = getDiffingResultQuery(
    projectStatus.projectKey,
    project.beforeVersionId,
    project.afterVersionId,
    pageId, // pageId의 값이 바뀌면 React Query 호출됨
    projectStatus.accessToken,
  );
```

### 3. 변경 영역 노드가 아닌 다른 노드 클릭시 UI상에 보여질 기본값 설정
  - UI에서는 `UNCHANGE_NODE` 일 경우 변경사항 텍스트 기본값으로 설정
```
if (differences === "UNCHANGED_NODE") {
  setDisplayText({
    titleOfChanges: null,
    detailOfChanges: ["변경사항을 선택해주세요."],
    className: "default",
  });
} else {
...
// 선택한 노드가 differenceRectangleIdList 와 일치하는 경우
...
```

<br />

## 잠깐! 확인해보셨나요?

- [x]  셀프 리뷰는 완료하셨나요?
- [x]  가장 최신 브랜치를 pull했나요?
- [x]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [x]  코드 컨벤션을 모두 지켰나요?
- [x]  적절한 라벨이 있나요?
- [x]  assignee가 있나요?

<br />

## Attachment(선택사항) 

1. 다른 페이지 이동후 현재 페이지 복귀시 캐싱되있는 결과 데이터 바로 렌더링
 ![페이지이동시 쿼리재요청](https://github.com/Figci/Figci-Plugin-Client/assets/95596243/300273bb-41c4-4775-8236-2dad4cb3db1d)

2. 변경노드 아닌 노드 클릭시 변경사항 텍스트 기본값으로 설정
 ![Feb-22-2024 00-21-35](https://github.com/Figci/Figci-Plugin-Client/assets/95596243/04ac1be0-6725-4abe-8c82-e8d684b6db9c)


<br />
