### PR TITLE
Feature: UTC to KST 포맷함수 구현

### DIFF
--- a/src/constants/config.js
+++ b/src/constants/config.js
@@ -2,6 +2,7 @@ const CONFIG = {
   DELAY_TIME_POLLING: 2000,
   NEW_NODE: "이전 버전엔 없던 새로운 요소에요!",
   NEW_FRAME: "이전 버전엔 없던 새로운 프레임이에요!",
+  TIME_GAP_MS: 9 * 60 * 60 * 1000,
 };
 
 export default CONFIG;

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -108,7 +108,7 @@ const formatTime = dateString => {
   const date = koreaTime.getDate();
 
   const hour = koreaTime.getHours();
-  const AmPm = hour >= 12 ? "PM" : "AM";
+  const ampm = hour >= 12 ? "PM" : "AM";
   const formattedHour = hour % 12 || 12;
   const minutes =
     koreaTime.getMinutes() < 10
@@ -116,7 +116,7 @@ const formatTime = dateString => {
       : koreaTime.getMinutes();
 
   const formattedDate = `${year}-${month}-${date}`;
-  const formattedTime = `${formattedHour}:${minutes} ${AmPm}`;
+  const formattedTime = `${formattedHour}:${minutes} ${ampm}`;
 
   return { formattedDate, formattedTime };
 };

--- a/src/store/projectVersion.js
+++ b/src/store/projectVersion.js
@@ -1,5 +1,7 @@
 import { create } from "zustand";
 
+import formatTime from "../utils/formatTime";
+
 const store = set => {
   return {
     byDates: {},
@@ -7,7 +9,8 @@ const store = set => {
     setVersion: versionList => {
       versionList.forEach(version => {
         const { id, created_at: createdAt, label } = version;
-        const [createdDate, createdTime] = createdAt.split("T");
+        const { formattedDate: createdDate, formattedTime: createdTime } =
+          formatTime(createdAt);
 
         return set(state => {
           if (!state.byDates[createdDate]) {
@@ -18,7 +21,7 @@ const store = set => {
             ...state.byDates,
             [createdDate]: {
               ...state.byDates[createdDate],
-              [id]: { label: label || createdTime.slice(0, -4), createdAt },
+              [id]: { label: label || createdTime, createdAt },
             },
           };
 

--- a/src/utils/formatTime.js
+++ b/src/utils/formatTime.js
@@ -1,0 +1,28 @@
+import CONFIG from "../constants/config";
+
+const formatTime = dateString => {
+  const currentDate = new Date(dateString);
+  const utcMS =
+    currentDate.getTime() + currentDate.getTimezoneOffset() * 60 * 1000;
+
+  const koreaTime = new Date(utcMS + CONFIG.TIME_GAP_MS);
+
+  const year = koreaTime.getFullYear();
+  const month = koreaTime.getMonth();
+  const date = koreaTime.getDate();
+
+  const hour = koreaTime.getHours();
+  const AmPm = hour >= 12 ? "PM" : "AM";
+  const formattedHour = hour % 12 || 12;
+  const minutes =
+    koreaTime.getMinutes() < 10
+      ? `0${koreaTime.getMinutes()}`
+      : koreaTime.getMinutes();
+
+  const formattedDate = `${year}-${month}-${date}`;
+  const formattedTime = `${formattedHour}:${minutes} ${AmPm}`;
+
+  return { formattedDate, formattedTime };
+};
+
+export default formatTime;


### PR DESCRIPTION
## Fix (이슈 번호)
None

<br />

## 해결하려던 문제를 알려주세요!
피그마에서 `Autosave`를 하게 되면 save된 `시간:분 AM || PM` 형식으로 저장이 되는데
피그마에 보이는 것은 KST로 보이지만, `rest API`로 받아오게 되는 버전 정보는 UTC로 나오기 때문에 시간 포매팅 작업이 필요했습니다.

![image](https://github.com/Figci/Figci-Plugin-Client/assets/48385389/effbbe3d-b1f2-4dd0-88bd-cef03b09b0a6)
→ figma 내부에서 `autoSave`될 시 보이는 해당 버전의 이름(KST)

<br/>

그러나 `rest API`에서 제공하는 정보는
![image](https://github.com/Figci/Figci-Plugin-Client/assets/48385389/2b347f6e-948f-40e3-b7ec-70aba2a5044a)
→ `created_at`을 보면 UTC로 작성되있는 것을 볼수 있습니다.

<br />

## 어떻게 해결했나요?
UTC시간을 KST로 포맷해줄 수 있는 formatTime을 구현했습니다.
이에 따라서 플러그인 내부에서 버전리스트들을 렌더를 할 시 created_at 값을 받아와서 formatTime을 수행한 결과로
렌더링을 진행 하게 됩니다.
\+
플러그인 환경에서 새로운 버전을 만들어 줄 때도 동일한 로직을 적용시켰습니다.

<br />

## 우려사항이 있나요?(선택사항)
1. `TIME_GAP_MS: 9 * 60 * 60 * 1000` 상수가 추가되었습니다

<br />

## 잠깐! 확인해보셨나요?
- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항)
![image](https://github.com/Figci/Figci-Plugin-Client/assets/48385389/50019e62-af7a-4662-95c8-98513133877d)
→ 피그마와 동일하게 포매팅 되서 렌더 되는 모습

<br />