### PR TITLE
Fix: 변경 페이지 - 변경 노드 name 기본값 설정

### DIFF
--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -29,7 +29,7 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
 
       const differenceRectangle = figma.createRectangle();
 
-      differenceRectangle.name = "Figci_New_Rectangle";
+      differenceRectangle.name = "Difference Rectangle Node";
       differenceRectangle.resize(
         width || CONSTANTS.MIN_SIZE_VALUE,
         height || CONSTANTS.MIN_SIZE_VALUE,
@@ -70,7 +70,7 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
         const differenceRectangle = figma.createRectangle();
         const { x, y, width, height } = modifiedFrames[frameId];
 
-        differenceRectangle.name = "Figci_New_Rectangle";
+        differenceRectangle.name = "Difference Rectangle Node";
         differenceRectangle.resize(width, height);
         differenceRectangle.x = x;
         differenceRectangle.y = y;

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -29,7 +29,7 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
 
       const differenceRectangle = figma.createRectangle();
 
-      differenceRectangle.name = "Difference Rectangle Node";
+      differenceRectangle.name = "Figci_New_Rectangle";
       differenceRectangle.resize(
         width || CONSTANTS.MIN_SIZE_VALUE,
         height || CONSTANTS.MIN_SIZE_VALUE,
@@ -70,6 +70,7 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
         const differenceRectangle = figma.createRectangle();
         const { x, y, width, height } = modifiedFrames[frameId];
 
+        differenceRectangle.name = "Figci_New_Rectangle";
         differenceRectangle.resize(width, height);
         differenceRectangle.x = x;
         differenceRectangle.y = y;


### PR DESCRIPTION
## Fix (이슈 번호)

<br />

## 해결하려던 문제를 알려주세요!
변경 사항 rect 렌더 요청시 rect 노드 이름 설정 추가 하였습니다. 
플러그인 API를 활용해서 rectangle 렌더 요청시 이름이 기본값으로 설정되어서
이름을 선언하지 않는 경우 렌더되지 않는 오류가 발생하여서 이름 속성을 추가했습니다.
```
differenceRectangle.name = "Figci_New_Rectangle"; // name 속성 추가
differenceRectangle.resize(width, height);
differenceRectangle.x = x;
differenceRectangle.y = y;
differenceRectangle.fills = [CONSTANTS.NEW_FILLS];
...
// 나머지 Rectangle 요소들
...
```
