### PR TITLE
Fix : 페이지 변경 후 돌아올 시 렌더 안되는 버그 해결

### DIFF
--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -78,6 +78,8 @@ function Difference() {
           message: "이전 버전에 존재하지 않는 페이지 입니다.",
         });
 
+        setPageId("");
+
         return;
       }
 

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -98,6 +98,12 @@ function ProjectVersion() {
       }));
     }
 
+    if (ev.data.pluginMessage.type === "CHANGED_CURRENT_PAGE_ID") {
+      const pageId = ev.data.pluginMessage.content;
+
+      setProjectInformation(currentState => ({ ...currentState, pageId }));
+    }
+
     setIsVersionLoading(false);
   };
 
@@ -117,6 +123,8 @@ function ProjectVersion() {
     setIsVersionLoading(true);
 
     if (!selectedBefore.beforeVersion) {
+      setIsVersionLoading(false);
+
       setToast({ status: true, message: "선택하지 않은 버전이 존재합니다." });
 
       return;
@@ -137,6 +145,8 @@ function ProjectVersion() {
     setPages(responseResult.content);
 
     if (responseResult.result === "error") {
+      setIsVersionLoading(false);
+
       setToast({ status: true, message: responseResult.message });
 
       return;
@@ -146,6 +156,8 @@ function ProjectVersion() {
     const currentPageId = projectInformation.pageId;
 
     if (!isCommonPage(commonPageList, currentPageId)) {
+      setIsVersionLoading(false);
+
       setToast({
         status: true,
         message: "선택하신 버전에는 현재 페이지가 존재하지 않습니다!",


### PR DESCRIPTION
## Fix (이슈 번호)
None

<br />

## 해결하려던 문제를 알려주세요!
`Difference`컴포넌트가 마운트 되어져 있는 상태에서
변경사항이 있는 페이지에서 사용자가 이전버전에는 존재하지 않는 페이지로 이동 후,
다시 변경사항이 있는 기존 페이지로 돌아왔을 경우 기존에 렌더되던 변경사항 `Rectangle`이 렌더되지 않는 문제가 있었습니다.

<br />

## 어떻게 해결했나요?
`react-query`는 `pageId`값에 의존성을 두고, 해당 값이 바뀌면 diffing결과를 반환합니다.

변경사항이 없는 페이지로 이동 시에 분기처리를 해주어 early return을 시킴으로써
Difference 컴포넌트의 내부에서 local state로 관리하고있는 pageId가 set되지 않기 때문에, 기존의 변경사항이 있는 pageId를 그대로 갖고있었습니다.

이에따라 기존 변경사항이 있는 페이지로 돌아오게 되더라도, pageId값은 바뀌지 않으므로 `diffingResult`또한 바뀌지 않고
변경사항을 렌더해주는 로직은 diffingResult에 의존성을 두고 useEffect내부에서 호출되기 때문에 렌더가 되지 않았던 것 입니다.

따라서 존재하지않는 페이지로 이동 해서 return이 되기 전에 `pageId`값을 빈문자열(`""`) 로 초기화를 해줌으로써 다시 돌아왔을 때 `pageId`값이 바뀔 수 있게 해주었습니다.

<br />

## 우려사항이 있나요?(선택사항)
1. 버전선택 페이지가 마운트 되어져 있을 때 유저가 페이지를 이동하면 이동한 페이지 id값을 최신화 하지 않고 있었기 때문에 이에따른 대응도 추가했습니다.
2. 버전선택 페이지에서 `loading`컴포넌트를 마운트 시키고, 에러가 발생하면 `loading`컴포넌트를 `언마운트` 시키는 로직이 식별되지 않아서 `loading`컴포넌트를 `언마운트` 시키는 로직도 추가했습니다.

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?
