### PR TITLE
Refactor: Difference Rectangle UI 변경

### DIFF
--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -5,13 +5,24 @@ const differenceRectangleIdList = [];
 const CONSTANTS = {
   MODIFIED_FILLS: {
     type: "SOLID",
-    color: { r: 0.976, g: 0.407, b: 0.329 },
+    color: { r: 1, g: 0.419, b: 0 },
+    opacity: 0.000001,
+  },
+  MODIFIED_STROKES: {
+    type: "SOLID",
+    color: { r: 1, g: 0.419, b: 0 },
+    opacity: 0.6,
   },
   NEW_FILLS: {
     type: "SOLID",
-    color: { r: 0.435, g: 0.831, b: 0.505 },
+    color: { r: 0.129, g: 0.8, b: 0.239 },
+    opacity: 0.000001,
   },
-  RECT_OPACITY: 0.2,
+  NEW_STROKES: {
+    type: "SOLID",
+    color: { r: 0.129, g: 0.8, b: 0.239 },
+    opacity: 1,
+  },
   MIN_SIZE_VALUE: 1,
   TIME_GAP_MS: 9 * 60 * 60 * 1000,
 };
@@ -31,16 +42,18 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
 
       differenceRectangle.name = "Difference Rectangle Node";
       differenceRectangle.resize(
-        width || CONSTANTS.MIN_SIZE_VALUE,
-        height || CONSTANTS.MIN_SIZE_VALUE,
+        width + 6 || CONSTANTS.MIN_SIZE_VALUE,
+        height + 6 || CONSTANTS.MIN_SIZE_VALUE,
       );
-      differenceRectangle.x = x;
-      differenceRectangle.y = y;
-      differenceRectangle.opacity = CONSTANTS.RECT_OPACITY;
+      differenceRectangle.x = x - 3;
+      differenceRectangle.y = y - 3;
 
       switch (type) {
         case "NEW":
           differenceRectangle.fills = [CONSTANTS.NEW_FILLS];
+          differenceRectangle.strokes = [CONSTANTS.NEW_STROKES];
+          differenceRectangle.strokeWeight = 3;
+          differenceRectangle.strokeAlign = "OUTSIDE";
           differenceRectangle.setPluginData(
             "differenceInformation",
             "이전 버전엔 없던 새로운 요소에요!",
@@ -49,6 +62,9 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
           break;
         case "MODIFIED":
           differenceRectangle.fills = [CONSTANTS.MODIFIED_FILLS];
+          differenceRectangle.strokes = [CONSTANTS.MODIFIED_STROKES];
+          differenceRectangle.strokeWeight = 3;
+          differenceRectangle.strokeAlign = "OUTSIDE";
           differenceRectangle.setPluginData(
             "differenceInformation",
             JSON.stringify(differenceInformation),
@@ -71,11 +87,13 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
         const { x, y, width, height } = modifiedFrames[frameId];
 
         differenceRectangle.name = "Difference Rectangle Node";
-        differenceRectangle.resize(width, height);
-        differenceRectangle.x = x;
-        differenceRectangle.y = y;
+        differenceRectangle.resize(width + 6, height + 6);
+        differenceRectangle.x = x - 3;
+        differenceRectangle.y = y - 3;
         differenceRectangle.fills = [CONSTANTS.NEW_FILLS];
-        differenceRectangle.opacity = CONSTANTS.RECT_OPACITY;
+        differenceRectangle.strokes = [CONSTANTS.NEW_STROKES];
+        differenceRectangle.strokeWeight = 3;
+        differenceRectangle.strokeAlign = "OUTSIDE";
         differenceRectangle.setPluginData(
           "differenceInformation",
           "이전 버전엔 없던 새로운 프레임이에요!",


### PR DESCRIPTION
## Fix (이슈 번호)
None

<br />

## 해결하려던 문제를 알려주세요!
기존에는 `backgroundColor`로 변경사항이 있거나, 새로생긴 요소를 표시해주었는데,
변경사항을 시각적으로 확인하는데 불편함이 있을 것 같다는 판단 하에 변경사항을 `border`로 변경하였습니다.

<br />

## 어떻게 해결했나요?
`Difference Rectangle`에 렌더해 줄 때 `stroke`속성을 추가해주었습니다.
다만, 이때 기존에 사용하던 `fills`의 `opacity`를 `0`으로 주었을 경우에 해당 `rectangle`을 클릭하면 클릭이 되지 않고, 꼭 `stroke`만 클릭해야지 인식이 되는 이슈가 있어서
`fills`의 opacity를 `0.0001`이라는 작은 값을 넣어줌으로써 해결했습니다.

<br />

## 우려사항이 있나요?(선택사항)
추가적으로 변경사항의 테두리가 기존 요소의 테두리와 겹치지 않도록 상•하 좌•우 3px씩 떨어트려서 렌더 되도록 수정하였습니다.

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 
<img width="461" alt="image" src="https://github.com/Figci/Figci-Plugin-Client/assets/48385389/165c9058-fd9e-481b-9a62-7463da72aede">
<br/>
→ 리팩토링 전

<br/>
<br />

<img width="142" alt="image" src="https://github.com/Figci/Figci-Plugin-Client/assets/48385389/479aa9fa-4bac-41c2-a621-d735e970403f">
<br/>
→ 리팩토링 후 변경사항 프레임

<br/>
<br />

<img width="394" alt="image" src="https://github.com/Figci/Figci-Plugin-Client/assets/48385389/9911b4f5-a27b-494a-8d5f-a1cbc96b37a4">
<br/>
→ 리팩토링 후 새로생긴 프레임

<br />
