### PR TITLE
Feat: 프로젝트 URL 입력 페이지 추가 및 ProjectKey 글로별 변수 저장

### DIFF
--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -154,15 +154,6 @@ figma.ui.onmessage = async message => {
     });
   }
 
-  if (message.type === "GET_PROJECT_KEY") {
-    const projectKey = figma.fileKey;
-
-    figma.ui.postMessage({
-      type: "GET_PROJECT_KEY",
-      content: projectKey,
-    });
-  }
-
   if (message.type === "GET_CURRENT_PAGE_ID") {
     const currentPageId = figma.currentPage.id;
 

--- a/src/store/project.js
+++ b/src/store/project.js
@@ -2,6 +2,7 @@ import { create } from "zustand";
 
 const projectStore = set => ({
   project: {
+    projectKey: "",
     beforeVersionId: "",
     afterVersionId: "",
   },
@@ -17,6 +18,7 @@ const projectStore = set => ({
     set(state => ({
       ...state,
       project: {
+        projectKey: "",
         beforeVersionId: "",
         afterVersionId: "",
       },

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -6,6 +6,7 @@ import Login from "./components/Login";
 import Onboarding from "./components/Onboarding";
 import ProjectVersion from "./components/ProjectVersion";
 import Difference from "./components/Difference";
+import NewProject from "./components/NewProject";
 
 function App() {
   return (
@@ -15,6 +16,7 @@ function App() {
         <Route path="/" exact element={<Login />} />
         <Route path="/onboarding" exact element={<Onboarding />} />
         <Route element={<Layout />}>
+          <Route path="/" element={<NewProject />} />
           <Route path="/version" element={<ProjectVersion />} />
           <Route path="/result" element={<Difference />} />
         </Route>

--- a/src/ui/App.jsx
+++ b/src/ui/App.jsx
@@ -16,7 +16,7 @@ function App() {
         <Route path="/" exact element={<Login />} />
         <Route path="/onboarding" exact element={<Onboarding />} />
         <Route element={<Layout />}>
-          <Route path="/" element={<NewProject />} />
+          <Route path="/new" element={<NewProject />} />
           <Route path="/version" element={<ProjectVersion />} />
           <Route path="/result" element={<Difference />} />
         </Route>

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -13,15 +13,16 @@ import usePageListStore from "../../../store/projectPage";
 import useProjectStore from "../../../store/project";
 
 import getDiffingResultQuery from "../../../services/getDiffingResultQuery";
+
 import isOwnProperty from "../../../utils/isOwnProperty";
 import postMessage from "../../../utils/postMessage";
 import processDifferences from "../../../utils/processDifferences";
 
 function Difference() {
   const [toast, setToast] = useState({});
-  const [pageId, setPageId] = useState("");
   const [isOpenedPopup, setIsOpenedPopup] = useState(false);
-  const [projectStatus, setProjectStatus] = useState({});
+  const [accessToken, setAccessToken] = useState("");
+  const [pageId, setPageId] = useState("");
   const [displayText, setDisplayText] = useState({
     titleOfChanges: null,
     detailOfChanges: ["변경사항을 선택해주세요."],
@@ -32,11 +33,11 @@ function Difference() {
   const { project } = useProjectStore();
 
   const { data: diffingResult, isLoading } = getDiffingResultQuery(
-    projectStatus.projectKey,
+    project.projectKey,
     project.beforeVersionId,
     project.afterVersionId,
     pageId,
-    projectStatus.accessToken,
+    accessToken,
   );
 
   const handleRectangleClick = ev => {
@@ -56,16 +57,10 @@ function Difference() {
       }
     }
 
-    if (ev.data.pluginMessage.type === "GET_PROJECT_KEY") {
-      const projectKey = ev.data.pluginMessage.content;
-
-      setProjectStatus(projectStatus => ({ ...projectStatus, projectKey }));
-    }
-
     if (ev.data.pluginMessage.type === "GET_ACCESS_TOKEN") {
-      const accessToken = ev.data.pluginMessage.content;
+      const token = ev.data.pluginMessage.content;
 
-      setProjectStatus(projectStatus => ({ ...projectStatus, accessToken }));
+      setAccessToken(token);
     }
 
     if (ev.data.pluginMessage.type === "CHANGED_CURRENT_PAGE_ID") {
@@ -122,7 +117,6 @@ function Difference() {
   }, [diffingResult]);
 
   useEffect(() => {
-    postMessage("GET_PROJECT_KEY");
     postMessage("GET_ACCESS_TOKEN");
 
     window.addEventListener("message", handleRectangleClick);

--- a/src/ui/components/Login/index.jsx
+++ b/src/ui/components/Login/index.jsx
@@ -67,7 +67,7 @@ function Login() {
 }
 
 const LogoImage = styled.img`
-  width: 120px;
+  width: 100px;
   margin-bottom: 24px;
 `;
 
@@ -76,7 +76,7 @@ const Description = styled.span`
   margin-bottom: 36px;
 
   color: #343e40;
-  font-size: 1rem;
+  font-size: 0.9rem;
   text-align: center;
   line-height: 24px;
 `;

--- a/src/ui/components/NewProject/index.jsx
+++ b/src/ui/components/NewProject/index.jsx
@@ -2,9 +2,10 @@ import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
+import Button from "../shared/Button";
+import Description from "../shared/Description";
 import Modal from "../shared/Modal";
 import Loading from "../shared/Loading";
-import Button from "../shared/Button";
 import ToastPopup from "../shared/Toast";
 
 import useProjectVersionStore from "../../../store/projectVersion";
@@ -45,7 +46,6 @@ function NewProject() {
 
       if (allVersions.result === "error") {
         setIsLoading(false);
-
         setToast({ status: true, message: allVersions.message });
 
         return;
@@ -65,6 +65,8 @@ function NewProject() {
 
       navigate("/version");
     }
+
+    setIsLoading(false);
   };
 
   useEffect(() => {
@@ -117,11 +119,17 @@ function NewProject() {
               placeholder="url 주소를 입력해주세요. (예: www.figma.com/abc)"
               onChange={handleChangeInput}
             />
+            <Description
+              className="description"
+              size="medium"
+              align="left"
+              text="맥은 'Command+L', 윈도우는 'Ctrl+L' 키를 누르면 링크가 복사돼요!"
+            />
           </label>
           <Button
             handleClick={handleSubmitURI}
             usingCase="solid"
-            size="small"
+            size="medium"
             className="next"
           >
             다음
@@ -136,9 +144,6 @@ function NewProject() {
 }
 
 const ContentsWrapper = styled.div`
-  box-sizing: border-box;
-  width: 100%;
-  height: 100%;
   padding: 24px;
 
   .step {
@@ -152,7 +157,7 @@ const ContentsWrapper = styled.div`
   }
 
   .title {
-    margin-bottom: 48px;
+    padding: 0 0 40px 0;
 
     color: #000000;
     font-size: 1.125rem;
@@ -171,10 +176,10 @@ const ContentsWrapper = styled.div`
     width: 100%;
     height: 48px;
     padding: 0px 12px;
-    border-radius: 4px;
-    border: 1px solid #000000;
     margin-top: 12px;
     margin-bottom: 12px;
+    border: 1.5px solid #000000;
+    border-radius: 4px;
 
     background-color: #ffffff;
     font-size: 0.75rem;
@@ -193,8 +198,15 @@ const ContentsWrapper = styled.div`
     font-weight: 700;
   }
 
+  .description {
+    color: #868e96;
+  }
+
   Button {
-    width: 100%;
+    position: fixed;
+
+    width: 355px;
+    bottom: 24px;
   }
 `;
 

--- a/src/ui/components/NewProject/index.jsx
+++ b/src/ui/components/NewProject/index.jsx
@@ -1,0 +1,201 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import styled from "styled-components";
+
+import Modal from "../shared/Modal";
+import Loading from "../shared/Loading";
+import Button from "../shared/Button";
+import ToastPopup from "../shared/Toast";
+
+import useProjectVersionStore from "../../../store/projectVersion";
+import useProjectStore from "../../../store/project";
+
+import getAllVersions from "../../../services/getAllVersions";
+
+import getProjectKeyFromURI from "../../../utils/getProjectKeyFromURI";
+import isValidFigmaUrl from "../../../utils/isValidFigmaUrl";
+import postMessage from "../../../utils/postMessage";
+
+function NewProject() {
+  const navigate = useNavigate();
+
+  const [toast, setToast] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [projectUrl, setProjectUrl] = useState("");
+
+  const { setVersion, clearVersion } = useProjectVersionStore();
+  const { project, setProject, clearProject } = useProjectStore();
+
+  useEffect(() => {
+    clearProject();
+    clearVersion();
+  }, []);
+
+  const handleChangeInput = ev => {
+    setProjectUrl(ev.target.value);
+  };
+
+  const handleMessage = async ev => {
+    setIsLoading(true);
+
+    if (ev.data.pluginMessage.type === "GET_ACCESS_TOKEN") {
+      const token = ev.data.pluginMessage.content;
+      const projectKey = getProjectKeyFromURI(projectUrl);
+      const allVersions = await getAllVersions(projectKey, token);
+
+      if (allVersions.result === "error") {
+        setIsLoading(false);
+
+        setToast({ status: true, message: allVersions.message });
+
+        return;
+      }
+
+      setProject({ projectKey });
+      setVersion(allVersions.content);
+
+      postMessage("GET_NEW_VERSION_ID");
+    }
+
+    if (ev.data.pluginMessage.type === "GET_NEW_VERSION_ID") {
+      const newVersionId = ev.data.pluginMessage.content;
+
+      setProject({ afterVersionId: newVersionId.id });
+      setIsLoading(false);
+
+      navigate("/version");
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("message", handleMessage);
+
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, [projectUrl]);
+
+  const handleSubmitURI = async ev => {
+    ev.preventDefault();
+
+    if (!isValidFigmaUrl(projectUrl)) {
+      setToast({
+        status: true,
+        message: "피그마 파일 URL 주소가 아니에요. 다시 입력해주세요🥲",
+      });
+
+      return;
+    }
+
+    postMessage("GET_ACCESS_TOKEN");
+  };
+
+  return (
+    <>
+      {isLoading && (
+        <Modal>
+          <Loading
+            title="버전 정보를 가져오고 있어요!"
+            text="이전 버전과 현재 버전을 저장하고 있어요.\n버전을 받아오는 동안 잠깐만 기다려주세요."
+          />
+        </Modal>
+      )}
+      <ContentsWrapper>
+        <form>
+          <div>
+            <h1 className="step">STEP 01</h1>
+            <h1 className="title">
+              디자인 변경사항을 확인할 <br />
+              피그마 프로젝트 URL을 입력해주세요.
+            </h1>
+          </div>
+          <label htmlFor="projectUrl" className="label">
+            피그마 프로젝트 URL 입력
+            <input
+              id="projectUrl"
+              defaultValue={project.projectUrl}
+              placeholder="url 주소를 입력해주세요. (예: www.figma.com/abc)"
+              onChange={handleChangeInput}
+            />
+          </label>
+          <Button
+            handleClick={handleSubmitURI}
+            usingCase="solid"
+            size="small"
+            className="next"
+          >
+            다음
+          </Button>
+        </form>
+      </ContentsWrapper>
+      {toast.status && (
+        <ToastPopup setToast={setToast} message={toast.message} />
+      )}
+    </>
+  );
+}
+
+const ContentsWrapper = styled.div`
+  box-sizing: border-box;
+  width: 100%;
+  height: 100%;
+  padding: 24px;
+
+  .step {
+    margin-bottom: 4px;
+
+    color: #2623fb;
+    font-size: 1.125rem;
+    line-height: 28px;
+    text-align: left;
+    font-weight: 800;
+  }
+
+  .title {
+    margin-bottom: 48px;
+
+    color: #000000;
+    font-size: 1.125rem;
+    line-height: 28px;
+    text-align: left;
+    font-weight: 800;
+  }
+
+  form {
+    width: 100%;
+    height: 100%;
+  }
+
+  input {
+    display: flex;
+    width: 100%;
+    height: 48px;
+    padding: 0px 12px;
+    border-radius: 4px;
+    border: 1px solid #000000;
+    margin-top: 12px;
+    margin-bottom: 12px;
+
+    background-color: #ffffff;
+    font-size: 0.75rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 18px;
+  }
+
+  label {
+    height: 100%;
+
+    color: #000000;
+    font-size: 0.813rem;
+    text-align: left;
+    line-height: 16px;
+    font-weight: 700;
+  }
+
+  Button {
+    width: 100%;
+  }
+`;
+
+export default NewProject;

--- a/src/ui/components/Onboarding/index.jsx
+++ b/src/ui/components/Onboarding/index.jsx
@@ -1,128 +1,38 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
-import Modal from "../shared/Modal";
-import Loading from "../shared/Loading";
 import Button from "../shared/Button";
-import ToastPopup from "../shared/Toast";
 
-import useProjectVersionStore from "../../../store/projectVersion";
-import useProjectStore from "../../../store/project";
-
-import postMessage from "../../../utils/postMessage";
-import getAllVersions from "../../../services/getAllVersions";
 import figciLogo from "../../../../assets/logo_figci.png";
 import onboarding from "../../../../assets/onboarding.png";
 
 function Onboarding() {
   const navigate = useNavigate();
 
-  const [isLoading, setIsLoading] = useState(false);
-  const [projectInformation, setProjectInformation] = useState({});
-  const [toast, setToast] = useState({});
-
-  const { setVersion, clearVersion } = useProjectVersionStore();
-  const { setProject } = useProjectStore();
-
-  const handleMessage = async ev => {
-    if (ev.data.pluginMessage.type === "GET_ACCESS_TOKEN") {
-      const token = ev.data.pluginMessage.content;
-
-      setProjectInformation(currentState => ({
-        ...currentState,
-        token,
-      }));
-    }
-
-    if (ev.data.pluginMessage.type === "GET_PROJECT_KEY") {
-      const projectKey = ev.data.pluginMessage.content;
-
-      setProjectInformation(currentState => ({
-        ...currentState,
-        projectKey,
-      }));
-    }
-
-    if (ev.data.pluginMessage.type === "GET_NEW_VERSION_ID") {
-      const newVersionId = ev.data.pluginMessage.content;
-
-      setProject({ afterVersionId: newVersionId.id });
-
-      setIsLoading(false);
-
-      navigate("/version");
-    }
-  };
-
-  useEffect(() => {
-    clearVersion();
-  }, []);
-
-  useEffect(() => {
-    postMessage("GET_ACCESS_TOKEN");
-    postMessage("GET_PROJECT_KEY");
-
-    window.addEventListener("message", handleMessage);
-
-    return () => {
-      window.removeEventListener("message", handleMessage);
-    };
-  }, []);
-
   const handleClick = async ev => {
     ev.preventDefault();
 
-    setIsLoading(true);
-
-    const allVersions = await getAllVersions(
-      projectInformation.projectKey,
-      projectInformation.token,
-    );
-
-    if (allVersions.result === "error") {
-      setIsLoading(false);
-
-      setToast({ status: true, message: allVersions.message });
-
-      return;
-    }
-
-    setVersion(allVersions.content);
-
-    postMessage("GET_NEW_VERSION_ID");
+    navigate("/new");
   };
 
   return (
-    <>
-      {isLoading && (
-        <Modal>
-          <Loading
-            title="버전 정보를 가져오고 있어요!"
-            text="이전 버전과 현재 버전을 저장하고 있어요.\n버전을 받아오는 동안 잠깐만 기다려주세요."
-          />
-        </Modal>
-      )}
-      <OnboardingContainer>
-        <img className="logo" src={figciLogo} alt="figci-logo-img" />
-        <Title>
-          이전 버전만 선택하면 ✨
-          <br />
-          디자인된 화면의 변경사항을
-          <br />
-          모두 확인할 수 있어요!
-        </Title>
-        <ImgOnboarding src={onboarding} alt="onboarding" />
-        <div className="button">
-          <Button handleClick={handleClick} usingCase="solid" size="medium">
-            좋아요!
-          </Button>
-        </div>
-      </OnboardingContainer>
-      {toast.status && (
-        <ToastPopup setToast={setToast} message={toast.message} />
-      )}
-    </>
+    <OnboardingContainer>
+      <img className="logo" src={figciLogo} alt="figci-logo-img" />
+      <Title>
+        이전 버전만 선택하면 ✨
+        <br />
+        디자인된 화면의 변경사항을
+        <br />
+        모두 확인할 수 있어요!
+      </Title>
+      <ImgOnboarding src={onboarding} alt="onboarding" />
+      <div className="button">
+        <Button handleClick={handleClick} usingCase="solid" size="medium">
+          좋아요!
+        </Button>
+      </div>
+    </OnboardingContainer>
   );
 }
 

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -183,13 +183,14 @@ function ProjectVersion() {
       )}
       <Wrapper>
         <ContentHeader>
+          <h1 className="step">STEP 02</h1>
           <h1 className="title">
             현재 버전과 비교할 <br />
             이전 버전을 선택해 주세요.
           </h1>
           <Description
             className="title-description"
-            size="medium"
+            size="large"
             align="left"
             text="현재 보고 있으신 페이지 기준으로 비교해드려요."
           />
@@ -245,7 +246,17 @@ const Wrapper = styled.div`
 `;
 
 const ContentHeader = styled.div`
-  padding: 0 0 48px 0;
+  padding: 0 0 40px 0;
+
+  .step {
+    margin-bottom: 4px;
+
+    color: #2623fb;
+    font-size: 1.125rem;
+    line-height: 28px;
+    text-align: left;
+    font-weight: 800;
+  }
 
   .title {
     color: #000000;
@@ -253,6 +264,10 @@ const ContentHeader = styled.div`
     line-height: 24px;
     text-align: left;
     font-weight: 800;
+  }
+
+  .title-description {
+    margin-top: 4px;
   }
 `;
 
@@ -276,6 +291,12 @@ const VersionForm = styled.form`
     margin-top: 12px;
     border: 1.5px solid #000000;
     border-radius: 4px;
+
+    appearance: none;
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' stroke='currentColor' stroke-width='1.5' stroke-linecap='round' stroke-linejoin='round' %3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 1rem top 0.65rem;
+    background-size: 24px;
   }
 
   .beforeVersion {

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -12,12 +12,13 @@ import useProjectStore from "../../../store/project";
 import useProjectVersionStore from "../../../store/projectVersion";
 import usePageListStore from "../../../store/projectPage";
 
+import getCommonPages from "../../../services/getCommonPages";
+import getDiffingResultQuery from "../../../services/getDiffingResultQuery";
+
 import postMessage from "../../../utils/postMessage";
 import createOption from "../../../utils/createOption";
 import isCommonPage from "../../../utils/isCommonPage";
 import isOwnProperty from "../../../utils/isOwnProperty";
-import getCommonPages from "../../../services/getCommonPages";
-import getDiffingResultQuery from "../../../services/getDiffingResultQuery";
 
 function ProjectVersion() {
   const navigate = useNavigate();
@@ -38,7 +39,7 @@ function ProjectVersion() {
     isError,
     error,
   } = getDiffingResultQuery(
-    projectInformation.projectKey,
+    project.projectKey,
     project.beforeVersionId,
     project.afterVersionId,
     commonPageId,
@@ -78,15 +79,6 @@ function ProjectVersion() {
       const pageId = ev.data.pluginMessage.content;
 
       setProjectInformation(currentState => ({ ...currentState, pageId }));
-    }
-
-    if (ev.data.pluginMessage.type === "GET_PROJECT_KEY") {
-      const projectKey = ev.data.pluginMessage.content;
-
-      setProjectInformation(currentState => ({
-        ...currentState,
-        projectKey,
-      }));
     }
 
     if (ev.data.pluginMessage.type === "GET_ACCESS_TOKEN") {
@@ -131,14 +123,10 @@ function ProjectVersion() {
     }
 
     const { beforeVersion } = selectedBefore;
-    const { afterVersionId } = project;
-    const { projectKey, accessToken } = projectInformation;
-
     const responseResult = await getCommonPages(
-      projectKey,
+      project.projectKey,
       beforeVersion,
-      afterVersionId,
-      accessToken,
+      project.afterVersionId,
       projectInformation.accessToken,
     );
 
@@ -174,7 +162,6 @@ function ProjectVersion() {
 
   useEffect(() => {
     postMessage("GET_CURRENT_PAGE_ID");
-    postMessage("GET_PROJECT_KEY");
     postMessage("GET_ACCESS_TOKEN");
 
     window.addEventListener("message", handleProjectInformation);

--- a/src/utils/getProjectKeyFromURI.js
+++ b/src/utils/getProjectKeyFromURI.js
@@ -1,0 +1,9 @@
+const getProjectKeyFromURI = projectURI => {
+  const urlObject = new URL(projectURI);
+  const urlPathList = urlObject.pathname.split("/").filter(part => part !== "");
+  const projectKey = urlPathList[1];
+
+  return projectKey;
+};
+
+export default getProjectKeyFromURI;

--- a/src/utils/isValidFigmaUrl.js
+++ b/src/utils/isValidFigmaUrl.js
@@ -1,0 +1,8 @@
+const isValidFigmaUrl = figmaUrl => {
+  const figmaUrlPattern =
+    /^(?:https:\/\/)?(?:www\.)?figma\.com\/file\/([0-9a-zA-Z]{22,128})(?:\/?([^?]+)?(.*))?$/;
+
+  return figmaUrlPattern.test(figmaUrl);
+};
+
+export default isValidFigmaUrl;


### PR DESCRIPTION
## Fix (이슈 번호)
closed #30

<br />

## 해결하려던 문제를 알려주세요!
피그마 플러그인 배포를 위해 ProjectKey 추출을 위한 사용자 프로젝트 URL 입력 페이지를 추가해야 합니다.
프로젝트 URL에서 추출된 projectKey를 Store에 저장해야 합니다.

<br />

## 어떻게 해결했나요?

### Plugin(code.js) 코드 내 "GET_PROJECT_KEY" 로직 삭제
해당 로직은 배포를 위해 삭제되었습니다. 대신 `projectKey`를 `store`에 저장해
서버에 요청을 보낼 때마다 저장된 `projectKey`를 사용합니다.

```javascript
  if (message.type === "GET_PROJECT_KEY") {
    const projectKey = figma.fileKey;

    figma.ui.postMessage({
      type: "GET_PROJECT_KEY",
      content: projectKey,
    });
  }
``` 

<br />

### ProjectStore 내 projectKey 초기값 추가
```javascript
const projectStore = set => ({
  project: {
    projectKey: "",
    beforeVersionId: "",
    afterVersionId: "",
  },
``` 

<br />

### URL 입력 페이지 추가에 따른 디자인 변경사항 반영
- URL 입력 페이지 디자인과 description이 추가되었습니다.
- Step이 하나 더 생겨 버전 선택 페이지 내에서도 Step이 추가되었습니다.
- 초기 로그인 전 화면에 로고 크기를 디자인과 비슷하게 조정했습니다.

![2](https://github.com/Figci/Figci-Plugin-Client/assets/43771772/d66a7041-2931-45a1-af2b-f6cf9ffc3750)
![버전 선택](https://github.com/Figci/Figci-Plugin-Client/assets/43771772/8ce8797f-8edc-4ac0-9efc-0f0936cb77de)

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 
전체 상태값과 projectKey를 받는 로직이 변경되어 projectKey를 사용하는 
모든 로직 변경이 필요했습니다. 전반적으로 구동 테스트를 했는데 무리없이 돌아갔으나
각자 컴퓨터 내에서도 테스트 부탁드립니다!

https://github.com/Figci/Figci-Plugin-Client/assets/43771772/31cff55b-7bbe-49ef-9257-5c547fc9204f

<br />
