### PR TITLE
Feature: 변경 페이지 - 페이지네이션 구현

### DIFF
--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -35,6 +35,14 @@ const isOwnProperty = (targetObject, targetProperty) => {
   return Object.prototype.hasOwnProperty.call(targetObject, targetProperty);
 };
 
+const focusScreen = (nodeIndex = 0) => {
+  const targetNodeId = differenceRectangleIdList[nodeIndex];
+  const targetNode = figma.getNodeById(targetNodeId);
+
+  figma.viewport.scrollAndZoomIntoView([targetNode]);
+  figma.currentPage.selection = [targetNode];
+};
+
 const renderDifferenceRectangle = (differences, modifiedFrames) => {
   for (const nodeId in differences) {
     if (isOwnProperty(differences, nodeId)) {
@@ -189,11 +197,7 @@ figma.ui.onmessage = async message => {
 
     renderDifferenceRectangle(differences, modifiedFrames);
 
-    const startNodeId = differenceRectangleIdList[0];
-    const startNode = figma.getNodeById(startNodeId);
-
-    figma.viewport.scrollAndZoomIntoView([startNode]);
-    figma.currentPage.selection = [startNode];
+    focusScreen();
   }
 
   if (message.type === "PAGINATION_BUTTON") {
@@ -204,8 +208,9 @@ figma.ui.onmessage = async message => {
       currentSelection &&
       differenceRectangleIdList.includes(currentSelection.id)
     ) {
-      const currentNodeId = figma.currentPage.selection[0].id;
-      const currentIndex = differenceRectangleIdList.indexOf(currentNodeId);
+      const currentIndex = differenceRectangleIdList.indexOf(
+        currentSelection.id,
+      );
 
       let nextIndex;
 
@@ -221,18 +226,12 @@ figma.ui.onmessage = async message => {
           differencesNumber;
       }
 
-      const nextNodeId = differenceRectangleIdList[nextIndex];
-      const nextNode = figma.getNodeById(nextNodeId);
+      focusScreen(nextIndex);
 
-      figma.viewport.scrollAndZoomIntoView([nextNode]);
-      figma.currentPage.selection = [nextNode];
-    } else {
-      const startNodeId = differenceRectangleIdList[0];
-      const startNode = figma.getNodeById(startNodeId);
-
-      figma.viewport.scrollAndZoomIntoView([startNode]);
-      figma.currentPage.selection = [startNode];
+      return;
     }
+
+    focusScreen();
   }
 };
 

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -130,7 +130,7 @@ const formatTime = dateString => {
   const koreaTime = new Date(utcMS + CONSTANTS.TIME_GAP_MS);
 
   const year = koreaTime.getFullYear();
-  const month = koreaTime.getMonth();
+  const month = koreaTime.getMonth() + 1;
   const date = koreaTime.getDate();
 
   const hour = koreaTime.getHours();

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -192,44 +192,25 @@ figma.ui.onmessage = async message => {
     figma.currentPage.selection = [startNode];
   }
 
-  if (message.type === "PREV_DIFFERENCE_RECTANGLE") {
-    const isSelectedNode = figma.currentPage.selection[0];
+  if (message.type === "PAGINATION_BUTTON") {
+    const currentSelection = figma.currentPage.selection[0];
+    const differencesNumber = differenceRectangleIdList.length;
 
     if (
-      isSelectedNode &&
-      differenceRectangleIdList.includes(isSelectedNode.id)
+      currentSelection &&
+      differenceRectangleIdList.includes(currentSelection.id)
     ) {
       const currentNodeId = figma.currentPage.selection[0].id;
-      const currentNodeIndex = differenceRectangleIdList.indexOf(currentNodeId);
-      const prevNodeIndex =
-        (currentNodeIndex - 1) % differenceRectangleIdList.length;
-      const prevNodeId = differenceRectangleIdList[prevNodeIndex];
-      const prevNode = figma.getNodeById(prevNodeId);
+      const currentIndex = differenceRectangleIdList.indexOf(currentNodeId);
 
-      figma.viewport.scrollAndZoomIntoView([prevNode]);
-      figma.currentPage.selection = [prevNode];
-    } else {
-      const startNodeId = differenceRectangleIdList[0];
-      const startNode = figma.getNodeById(startNodeId);
+      let nextIndex;
+      if (message.content === "prev") {
+        nextIndex = (currentIndex - 1 + differencesNumber) % differencesNumber;
+      } else {
+        nextIndex = (currentIndex + 1) % differencesNumber;
+      }
 
-      figma.viewport.scrollAndZoomIntoView([startNode]);
-      figma.currentPage.selection = [startNode];
-    }
-    figma.notify(`이전 변경 사항이 선택 되었습니다.`);
-  }
-
-  if (message.type === "NEXT_DIFFERENCE_RECTANGLE") {
-    const isSelectedNode = figma.currentPage.selection[0];
-
-    if (
-      isSelectedNode &&
-      differenceRectangleIdList.includes(isSelectedNode.id)
-    ) {
-      const currentNodeId = figma.currentPage.selection[0].id;
-      const currentNodeIndex = differenceRectangleIdList.indexOf(currentNodeId);
-      const nextNodeIndex =
-        (currentNodeIndex + 1) % differenceRectangleIdList.length;
-      const nextNodeId = differenceRectangleIdList[nextNodeIndex];
+      const nextNodeId = differenceRectangleIdList[nextIndex];
       const nextNode = figma.getNodeById(nextNodeId);
 
       figma.viewport.scrollAndZoomIntoView([nextNode]);
@@ -241,26 +222,25 @@ figma.ui.onmessage = async message => {
       figma.viewport.scrollAndZoomIntoView([startNode]);
       figma.currentPage.selection = [startNode];
     }
-    figma.notify(`이전 변경 사항이 선택 되었습니다.`);
   }
 };
 
 figma.on("selectionchange", () => {
-  const selectedNode = figma.currentPage.selection[0];
+  const currentSelection = figma.currentPage.selection[0];
 
-  if (!selectedNode) {
+  if (!currentSelection) {
     return;
   }
 
   const totalFrameCount = differenceRectangleIdList.length;
 
-  if (differenceRectangleIdList.includes(selectedNode.id)) {
-    const differenceInformation = selectedNode.getPluginData(
+  if (differenceRectangleIdList.includes(currentSelection.id)) {
+    const differenceInformation = currentSelection.getPluginData(
       "differenceInformation",
     );
 
     const currentFrameIndex =
-      differenceRectangleIdList.indexOf(selectedNode.id) + 1;
+      differenceRectangleIdList.indexOf(currentSelection.id) + 1;
 
     figma.ui.postMessage({
       type: "FRAME_PAGINATION",

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -265,31 +265,35 @@ figma.on("selectionchange", () => {
       type: "RENDER_DIFFERENCE_INFORMATION",
       content: { differenceInformation },
     });
-  } else {
+
+    return;
+  }
+
+  figma.ui.postMessage({
+    type: "RENDER_DIFFERENCE_INFORMATION",
+    content: "UNCHANGED_NODE",
+  });
+
+  if (differencesNumber) {
     figma.ui.postMessage({
-      type: "RENDER_DIFFERENCE_INFORMATION",
-      content: "UNCHANGED_NODE",
+      type: "FRAME_PAGINATION",
+      content: {
+        result: true,
+        currentCount: 0,
+        frameCounts: differencesNumber,
+      },
     });
 
-    if (differencesNumber) {
-      figma.ui.postMessage({
-        type: "FRAME_PAGINATION",
-        content: {
-          result: true,
-          currentCount: 0,
-          frameCounts: differencesNumber,
-        },
-      });
-    } else {
-      figma.ui.postMessage({
-        type: "FRAME_PAGINATION",
-        content: {
-          result: false,
-          frameCounts: "- / -",
-        },
-      });
-    }
+    return;
   }
+
+  figma.ui.postMessage({
+    type: "FRAME_PAGINATION",
+    content: {
+      result: false,
+      frameCounts: "- / -",
+    },
+  });
 });
 
 figma.on("currentpagechange", () => {

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -25,6 +25,10 @@ const CONSTANTS = {
   },
   MIN_SIZE_VALUE: 1,
   TIME_GAP_MS: 9 * 60 * 60 * 1000,
+  PAGINATION: {
+    INDEX_INCREASE: 1,
+    INDEX_DECREASE: -1,
+  },
 };
 
 const isOwnProperty = (targetObject, targetProperty) => {
@@ -205,9 +209,15 @@ figma.ui.onmessage = async message => {
 
       let nextIndex;
       if (message.content === "prev") {
-        nextIndex = (currentIndex - 1 + differencesNumber) % differencesNumber;
+        nextIndex =
+          (currentIndex +
+            CONSTANTS.PAGINATION.INDEX_DECREASE +
+            differencesNumber) %
+          differencesNumber;
       } else {
-        nextIndex = (currentIndex + 1) % differencesNumber;
+        nextIndex =
+          (currentIndex + CONSTANTS.PAGINATION.INDEX_INCREASE) %
+          differencesNumber;
       }
 
       const nextNodeId = differenceRectangleIdList[nextIndex];
@@ -232,7 +242,7 @@ figma.on("selectionchange", () => {
     return;
   }
 
-  const totalFrameCount = differenceRectangleIdList.length;
+  const differencesNumber = differenceRectangleIdList.length;
 
   if (differenceRectangleIdList.includes(currentSelection.id)) {
     const differenceInformation = currentSelection.getPluginData(
@@ -247,7 +257,7 @@ figma.on("selectionchange", () => {
       content: {
         result: true,
         currentCount: currentFrameIndex,
-        frameCounts: totalFrameCount,
+        frameCounts: differencesNumber,
       },
     });
 
@@ -261,13 +271,13 @@ figma.on("selectionchange", () => {
       content: "UNCHANGED_NODE",
     });
 
-    if (totalFrameCount) {
+    if (differencesNumber) {
       figma.ui.postMessage({
         type: "FRAME_PAGINATION",
         content: {
           result: true,
           currentCount: 0,
-          frameCounts: totalFrameCount,
+          frameCounts: differencesNumber,
         },
       });
     } else {

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -208,6 +208,7 @@ figma.ui.onmessage = async message => {
       const currentIndex = differenceRectangleIdList.indexOf(currentNodeId);
 
       let nextIndex;
+
       if (message.content === "prev") {
         nextIndex =
           (currentIndex +

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -184,6 +184,12 @@ figma.ui.onmessage = async message => {
     clearRectangleNode();
 
     renderDifferenceRectangle(differences, modifiedFrames);
+
+    const startNodeId = differenceRectangleIdList[0];
+    const startNode = figma.getNodeById(startNodeId);
+
+    figma.viewport.scrollAndZoomIntoView([startNode]);
+    figma.currentPage.selection = [startNode];
   }
 
   if (message.type === "PREV_DIFFERENCE_RECTANGLE") {

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -186,12 +186,56 @@ figma.ui.onmessage = async message => {
     renderDifferenceRectangle(differences, modifiedFrames);
   }
 
-  if (message.type === "NEXT_DIFFERENCE_RECTANGLE") {
-    figma.notify(`이전 변경사항 노드 버튼이 선택되었습니다.`);
+  if (message.type === "PREV_DIFFERENCE_RECTANGLE") {
+    const isSelectedNode = figma.currentPage.selection[0];
+
+    if (
+      isSelectedNode &&
+      differenceRectangleIdList.includes(isSelectedNode.id)
+    ) {
+      const currentNodeId = figma.currentPage.selection[0].id;
+      const currentNodeIndex = differenceRectangleIdList.indexOf(currentNodeId);
+      const prevNodeIndex =
+        (currentNodeIndex - 1) % differenceRectangleIdList.length;
+      const prevNodeId = differenceRectangleIdList[prevNodeIndex];
+      const prevNode = figma.getNodeById(prevNodeId);
+
+      figma.viewport.scrollAndZoomIntoView([prevNode]);
+      figma.currentPage.selection = [prevNode];
+    } else {
+      const startNodeId = differenceRectangleIdList[0];
+      const startNode = figma.getNodeById(startNodeId);
+
+      figma.viewport.scrollAndZoomIntoView([startNode]);
+      figma.currentPage.selection = [startNode];
+    }
+    figma.notify(`이전 변경 사항이 선택 되었습니다.`);
   }
 
-  if (message.type === "PREV_DIFFERENCE_RECTANGLE") {
-    figma.notify(`다음 변경사항 노드 버튼이 선택되었습니다.`);
+  if (message.type === "NEXT_DIFFERENCE_RECTANGLE") {
+    const isSelectedNode = figma.currentPage.selection[0];
+
+    if (
+      isSelectedNode &&
+      differenceRectangleIdList.includes(isSelectedNode.id)
+    ) {
+      const currentNodeId = figma.currentPage.selection[0].id;
+      const currentNodeIndex = differenceRectangleIdList.indexOf(currentNodeId);
+      const nextNodeIndex =
+        (currentNodeIndex + 1) % differenceRectangleIdList.length;
+      const nextNodeId = differenceRectangleIdList[nextNodeIndex];
+      const nextNode = figma.getNodeById(nextNodeId);
+
+      figma.viewport.scrollAndZoomIntoView([nextNode]);
+      figma.currentPage.selection = [nextNode];
+    } else {
+      const startNodeId = differenceRectangleIdList[0];
+      const startNode = figma.getNodeById(startNodeId);
+
+      figma.viewport.scrollAndZoomIntoView([startNode]);
+      figma.currentPage.selection = [startNode];
+    }
+    figma.notify(`이전 변경 사항이 선택 되었습니다.`);
   }
 };
 

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -202,7 +202,7 @@ figma.ui.onmessage = async message => {
 
   if (message.type === "PAGINATION_BUTTON") {
     const currentSelection = figma.currentPage.selection[0];
-    const differencesNumber = differenceRectangleIdList.length;
+    const differencesLength = differenceRectangleIdList.length;
 
     if (
       currentSelection &&
@@ -218,12 +218,12 @@ figma.ui.onmessage = async message => {
         nextIndex =
           (currentIndex +
             CONSTANTS.PAGINATION.INDEX_DECREASE +
-            differencesNumber) %
-          differencesNumber;
+            differencesLength) %
+          differencesLength;
       } else {
         nextIndex =
           (currentIndex + CONSTANTS.PAGINATION.INDEX_INCREASE) %
-          differencesNumber;
+          differencesLength;
       }
 
       focusScreen(nextIndex);
@@ -242,7 +242,7 @@ figma.on("selectionchange", () => {
     return;
   }
 
-  const differencesNumber = differenceRectangleIdList.length;
+  const differencesLength = differenceRectangleIdList.length;
 
   if (differenceRectangleIdList.includes(currentSelection.id)) {
     const differenceInformation = currentSelection.getPluginData(
@@ -257,7 +257,7 @@ figma.on("selectionchange", () => {
       content: {
         result: true,
         currentCount: currentFrameIndex,
-        frameCounts: differencesNumber,
+        frameCounts: differencesLength,
       },
     });
 
@@ -274,13 +274,13 @@ figma.on("selectionchange", () => {
     content: "UNCHANGED_NODE",
   });
 
-  if (differencesNumber) {
+  if (differencesLength) {
     figma.ui.postMessage({
       type: "FRAME_PAGINATION",
       content: {
         result: true,
         currentCount: 0,
-        frameCounts: differencesNumber,
+        frameCounts: differencesLength,
       },
     });
 

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -76,6 +76,7 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
       }
 
       differenceRectangleIdList.push(differenceRectangle.id);
+
       modifiedFrames[frameId].isNew = false;
     }
   }
@@ -100,6 +101,8 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
         );
 
         differenceRectangleIdList.push(differenceRectangle.id);
+
+        differenceRectangleIdList.reverse();
       }
     }
   }

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -101,11 +101,11 @@ const renderDifferenceRectangle = (differences, modifiedFrames) => {
         );
 
         differenceRectangleIdList.push(differenceRectangle.id);
-
-        differenceRectangleIdList.reverse();
       }
     }
   }
+
+  differenceRectangleIdList.reverse();
 };
 
 const clearRectangleNode = () => {

--- a/src/plugin/code.js
+++ b/src/plugin/code.js
@@ -182,6 +182,14 @@ figma.ui.onmessage = async message => {
 
     renderDifferenceRectangle(differences, modifiedFrames);
   }
+
+  if (message.type === "NEXT_DIFFERENCE_RECTANGLE") {
+    figma.notify(`이전 변경사항 노드 버튼이 선택되었습니다.`);
+  }
+
+  if (message.type === "PREV_DIFFERENCE_RECTANGLE") {
+    figma.notify(`다음 변경사항 노드 버튼이 선택되었습니다.`);
+  }
 };
 
 figma.on("selectionchange", () => {
@@ -191,10 +199,24 @@ figma.on("selectionchange", () => {
     return;
   }
 
+  const totalFrameCount = differenceRectangleIdList.length;
+
   if (differenceRectangleIdList.includes(selectedNode.id)) {
     const differenceInformation = selectedNode.getPluginData(
       "differenceInformation",
     );
+
+    const currentFrameIndex =
+      differenceRectangleIdList.indexOf(selectedNode.id) + 1;
+
+    figma.ui.postMessage({
+      type: "FRAME_PAGINATION",
+      content: {
+        result: true,
+        currentCount: currentFrameIndex,
+        frameCounts: totalFrameCount,
+      },
+    });
 
     figma.ui.postMessage({
       type: "RENDER_DIFFERENCE_INFORMATION",
@@ -205,6 +227,25 @@ figma.on("selectionchange", () => {
       type: "RENDER_DIFFERENCE_INFORMATION",
       content: "UNCHANGED_NODE",
     });
+
+    if (totalFrameCount) {
+      figma.ui.postMessage({
+        type: "FRAME_PAGINATION",
+        content: {
+          result: true,
+          currentCount: 0,
+          frameCounts: totalFrameCount,
+        },
+      });
+    } else {
+      figma.ui.postMessage({
+        type: "FRAME_PAGINATION",
+        content: {
+          result: false,
+          frameCounts: "- / -",
+        },
+      });
+    }
   }
 });
 

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -1,8 +1,8 @@
 import React, { useState, useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 import { nanoid } from "nanoid";
 
-import { useLocation } from "react-router-dom";
 import Description from "../shared/Description";
 import Button from "../shared/Button";
 import ToastPopup from "../shared/Toast";
@@ -32,6 +32,7 @@ function Difference() {
     detailOfChanges: ["변경사항을 선택해주세요."],
     className: "default",
   });
+
   const location = useLocation();
 
   const { allPageIds } = usePageListStore();
@@ -90,6 +91,7 @@ function Difference() {
       setPagination(framePagination);
     }
   };
+
   useEffect(() => {
     setDisplayText({
       titleOfChanges: null,
@@ -122,6 +124,7 @@ function Difference() {
         modifiedFrames[frameId].isNew = true;
       }
     }
+
     setIsComparable(true);
     setPagination({
       result: true,
@@ -137,10 +140,8 @@ function Difference() {
 
     if (receivedFromVersionPage) {
       setIsComparable(receivedFromVersionPage.isExistDiffingResult);
-      setPagination(receivedFromVersionPage.paginationInitialValue);
     }
 
-    postMessage("GET_PROJECT_KEY");
     postMessage("GET_ACCESS_TOKEN");
 
     window.addEventListener("message", handleRectangleClick);

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -193,7 +193,7 @@ function Difference() {
             setIsOpenedPopup(true);
           }}
         >
-          버전
+          버전 재선택
         </Button>
         <h1 className="title">디자인 변경 사항을 확인해 보세요! 👀</h1>
         <Description
@@ -281,12 +281,14 @@ const Pagination = styled.div`
   }
 
   .pagination-prev-button {
+    border: 1px solid #868e96 !important;
     min-width: 140px !important;
     margin-right: 10px;
     text-align: center;
   }
 
   .pagination-next-button {
+    border: 1px solid #868e96 !important;
     min-width: 140px !important;
     text-align: center;
   }

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -26,7 +26,7 @@ function Difference() {
   const [pagination, setPagination] = useState("");
   const [pageId, setPageId] = useState("");
   const [accessToken, setAccessToken] = useState("");
-  const [isPaginationClicked, setIsPaginationClicked] = useState("");
+  const [clickedType, setClickedType] = useState({ type: "" });
   const [displayText, setDisplayText] = useState({
     titleOfChanges: null,
     detailOfChanges: ["변경사항을 선택해주세요."],
@@ -122,7 +122,7 @@ function Difference() {
         modifiedFrames[frameId].isNew = true;
       }
     }
-
+    setIsComparable(true);
     setPagination({
       result: true,
       currentCount: 0,
@@ -151,14 +151,12 @@ function Difference() {
   }, []);
 
   useEffect(() => {
-    if (isPaginationClicked.type === "prev") {
-      postMessage("PREV_DIFFERENCE_RECTANGLE");
+    if (clickedType.type === "prev") {
+      postMessage("PAGINATION_BUTTON", "prev");
+    } else {
+      postMessage("PAGINATION_BUTTON", "next");
     }
-
-    if (isPaginationClicked.type === "next") {
-      postMessage("NEXT_DIFFERENCE_RECTANGLE");
-    }
-  }, [isPaginationClicked]);
+  }, [clickedType]);
 
   return (
     <>
@@ -223,7 +221,7 @@ function Difference() {
                 className="pagination-prev-button"
                 size="small"
                 usingCase="line"
-                handleClick={() => setIsPaginationClicked({ type: "prev" })}
+                handleClick={() => setClickedType({ type: "prev" })}
               >
                 이전
               </Button>
@@ -231,7 +229,7 @@ function Difference() {
                 className="pagination-next-button"
                 size="small"
                 usingCase="line"
-                handleClick={() => setIsPaginationClicked({ type: "next" })}
+                handleClick={() => setClickedType({ type: "next" })}
               >
                 다음
               </Button>

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -32,8 +32,6 @@ function Difference() {
     className: "default",
   });
 
-  const location = useLocation();
-
   const { allPageIds } = usePageListStore();
   const { project } = useProjectStore();
 
@@ -48,18 +46,18 @@ function Difference() {
   const handleRectangleClick = ev => {
     if (ev.data.pluginMessage.type === "RENDER_DIFFERENCE_INFORMATION") {
       const differences = ev.data.pluginMessage.content;
-
       if (differences === "UNCHANGED_NODE") {
         setDisplayText({
           titleOfChanges: null,
           detailOfChanges: ["변경사항을 선택해주세요."],
           className: "default",
         });
-      } else {
-        const differencesInformation = processDifferences(differences);
-
-        setDisplayText(differencesInformation);
+        return;
       }
+
+      const differencesInformation = processDifferences(differences);
+
+      setDisplayText(differencesInformation);
     }
 
     if (ev.data.pluginMessage.type === "GET_ACCESS_TOKEN") {

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -281,14 +281,14 @@ const Pagination = styled.div`
   }
 
   .pagination-prev-button {
-    border: 1px solid #868e96 !important;
+    border: 1px solid #adb5bd;
     min-width: 140px !important;
     margin-right: 10px;
     text-align: center;
   }
 
   .pagination-next-button {
-    border: 1px solid #868e96 !important;
+    border: 1px solid #adb5bd;
     min-width: 140px !important;
     text-align: center;
   }

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -272,8 +272,8 @@ const Pagination = styled.div`
   .pagination-content {
     display: flex;
     align-items: center;
-    margin-right: 10px;
     width: 100px;
+    margin-right: 10px;
 
     text-align: left;
   }
@@ -287,8 +287,8 @@ const Pagination = styled.div`
   }
 
   .pagination-next-button {
-    border: 1px solid #adb5bd;
     min-width: 140px !important;
+    border: 1px solid #adb5bd;
 
     text-align: center;
   }
@@ -352,8 +352,9 @@ const Content = styled.div`
   }
 
   .description {
-    color: #868e96;
     margin-bottom: 24px;
+
+    color: #868e96;
   }
 `;
 

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -153,11 +153,11 @@ function Difference() {
 
   useEffect(() => {
     if (isPaginationClicked.type === "prev") {
-      postMessage("NEXT_DIFFERENCE_RECTANGLE");
+      postMessage("PREV_DIFFERENCE_RECTANGLE");
     }
 
     if (isPaginationClicked.type === "next") {
-      postMessage("PREV_DIFFERENCE_RECTANGLE");
+      postMessage("NEXT_DIFFERENCE_RECTANGLE");
     }
   }, [isPaginationClicked]);
 

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -18,6 +18,8 @@ import getDiffingResultQuery from "../../../services/getDiffingResultQuery";
 import isOwnProperty from "../../../utils/isOwnProperty";
 import postMessage from "../../../utils/postMessage";
 import processDifferences from "../../../utils/processDifferences";
+import postMessage from "../../../utils/postMessage";
+import isOwnProperty from "../../../utils/isOwnProperty";
 
 function Difference() {
   const [toast, setToast] = useState({});

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -18,15 +18,14 @@ import getDiffingResultQuery from "../../../services/getDiffingResultQuery";
 import isOwnProperty from "../../../utils/isOwnProperty";
 import postMessage from "../../../utils/postMessage";
 import processDifferences from "../../../utils/processDifferences";
-import postMessage from "../../../utils/postMessage";
-import isOwnProperty from "../../../utils/isOwnProperty";
 
 function Difference() {
   const [toast, setToast] = useState({});
   const [isOpenedPopup, setIsOpenedPopup] = useState(false);
-  const [projectStatus, setProjectStatus] = useState({});
   const [isComparable, setIsComparable] = useState(false);
   const [pagination, setPagination] = useState("");
+  const [pageId, setPageId] = useState("");
+  const [accessToken, setAccessToken] = useState("");
   const [isPaginationClicked, setIsPaginationClicked] = useState("");
   const [displayText, setDisplayText] = useState({
     titleOfChanges: null,
@@ -77,8 +76,6 @@ function Difference() {
         setIsComparable(false);
         setPageId("");
         setPagination({ result: false, frameCounts: "- / -" });
-
-        setPageId("");
 
         return;
       }

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -268,31 +268,36 @@ function Difference() {
 
 const Pagination = styled.div`
   display: flex;
+
   justify-content: space-between;
 
   .pagination-content {
     display: flex;
-    width: 100px;
     margin-right: 10px;
+    width: 100px;
+
     align-items: center;
     text-align: left;
   }
 
   .pagination-prev-button {
-    border: 1px solid #adb5bd;
     min-width: 140px !important;
     margin-right: 10px;
+    border: 1px solid #adb5bd;
+
     text-align: center;
   }
 
   .pagination-next-button {
     border: 1px solid #adb5bd;
     min-width: 140px !important;
+
     text-align: center;
   }
 
   .pagination-button-disable {
     border: 1px solid #868e96 !important;
+
     background-color: #868e96 !important;
   }
 `;

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -296,9 +296,9 @@ const Pagination = styled.div`
   }
 
   .pagination-button-disable {
-    border: 1px solid #868e96 !important;
+    border: 1px solid #868e96;
 
-    background-color: #868e96 !important;
+    background-color: #868e96;
   }
 `;
 

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -22,7 +22,10 @@ import processDifferences from "../../../utils/processDifferences";
 function Difference() {
   const [toast, setToast] = useState({});
   const [isOpenedPopup, setIsOpenedPopup] = useState(false);
-  const [pagination, setPagination] = useState("");
+  const [pagination, setPagination] = useState({
+    result: false,
+    frameCounts: "- / -",
+  });
   const [accessToken, setAccessToken] = useState("");
   const [pageId, setPageId] = useState("");
   const [clickedType, setClickedType] = useState({ type: "" });
@@ -208,7 +211,7 @@ function Difference() {
         </div>
         <Pagination>
           <div className="pagination-content">
-            {pagination && pagination.result
+            {pagination.result
               ? `${pagination.currentCount} / ${pagination.frameCounts}`
               : `${pagination.frameCounts}`}
           </div>

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -267,15 +267,14 @@ function Difference() {
 
 const Pagination = styled.div`
   display: flex;
-
   justify-content: space-between;
 
   .pagination-content {
     display: flex;
+    align-items: center;
     margin-right: 10px;
     width: 100px;
 
-    align-items: center;
     text-align: left;
   }
 

--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect } from "react";
-import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 import { nanoid } from "nanoid";
 
@@ -49,12 +48,14 @@ function Difference() {
   const handleRectangleClick = ev => {
     if (ev.data.pluginMessage.type === "RENDER_DIFFERENCE_INFORMATION") {
       const differences = ev.data.pluginMessage.content;
+
       if (differences === "UNCHANGED_NODE") {
         setDisplayText({
           titleOfChanges: null,
           detailOfChanges: ["변경사항을 선택해주세요."],
           className: "default",
         });
+
         return;
       }
 

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -71,11 +71,6 @@ function ProjectVersion() {
       navigate("/result", {
         state: {
           isExistDiffingResult: true,
-          paginationInitialValue: {
-            result: true,
-            currentCount: 0,
-            frameCounts: Object.keys(diffingResult.content.differences).length,
-          },
         },
       });
     }

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -68,7 +68,16 @@ function ProjectVersion() {
 
       postMessage("POST_DIFFING_RESULT", { differences, modifiedFrames });
 
-      navigate("/result");
+      navigate("/result", {
+        state: {
+          isExistDiffingResult: true,
+          paginationInitialValue: {
+            result: true,
+            currentCount: 0,
+            frameCounts: Object.keys(diffingResult.content.differences).length,
+          },
+        },
+      });
     }
   }, [diffingResult]);
 

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -68,11 +68,7 @@ function ProjectVersion() {
 
       postMessage("POST_DIFFING_RESULT", { differences, modifiedFrames });
 
-      navigate("/result", {
-        state: {
-          isExistDiffingResult: true,
-        },
-      });
+      navigate("/result");
     }
   }, [diffingResult]);
 

--- a/src/ui/components/shared/Button.jsx
+++ b/src/ui/components/shared/Button.jsx
@@ -31,7 +31,7 @@ const BUTTON_SIZES = {
 const USING_CASES = {
   void: css`
     --button-color: #ffffff;
-    --button-background-color: #868e96;
+    --button-background-color: #f1f3f5;
   `,
   solid: css`
     --button-color: #ffffff;

--- a/src/ui/components/shared/Button.jsx
+++ b/src/ui/components/shared/Button.jsx
@@ -1,6 +1,14 @@
 import styled, { css } from "styled-components";
 
 const BUTTON_SIZES = {
+  tiny: css`
+    --button-min-width: 95px;
+    --button-min-height: 20px;
+    --button-font-size: 0.815rem;
+    --button-font-weight: 700;
+    --button-padding: 8px 16px;
+    --button-radius: 20px;
+  `,
   small: css`
     --button-min-width: 150px;
     --button-min-height: 45px;
@@ -21,6 +29,10 @@ const BUTTON_SIZES = {
 };
 
 const USING_CASES = {
+  void: css`
+    --button-color: #ffffff;
+    --button-background-color: #868e96;
+  `,
   solid: css`
     --button-color: #ffffff;
     --button-background-color: #000000;

--- a/src/ui/components/shared/Button.jsx
+++ b/src/ui/components/shared/Button.jsx
@@ -1,7 +1,7 @@
 import styled, { css } from "styled-components";
 
 const BUTTON_SIZES = {
-  tiny: css`
+  xsmall: css`
     --button-min-width: 95px;
     --button-min-height: 20px;
     --button-font-size: 0.815rem;

--- a/src/ui/components/shared/Button.jsx
+++ b/src/ui/components/shared/Button.jsx
@@ -30,7 +30,7 @@ const BUTTON_SIZES = {
 
 const USING_CASES = {
   void: css`
-    --button-color: #ffffff;
+    --button-color: #000000;
     --button-background-color: #f1f3f5;
   `,
   solid: css`

--- a/src/utils/formatTime.js
+++ b/src/utils/formatTime.js
@@ -8,7 +8,7 @@ const formatTime = dateString => {
   const koreaTime = new Date(utcMS + CONFIG.TIME_GAP_MS);
 
   const year = koreaTime.getFullYear();
-  const month = koreaTime.getMonth();
+  const month = koreaTime.getMonth() + 1;
   const date = koreaTime.getDate();
 
   const hour = koreaTime.getHours();


### PR DESCRIPTION
## Fix (이슈 번호)
closes #31 

<br />

## 해결하려던 문제를 알려주세요!

- 플러그인 변경 페이지 - 변경된 노드의 페이지네이션 기능 구현
 1. 버전 재선택 버튼 위치 및 스타일 변경 - 헤더바 고정
 2. 페이지네이션 정보 표시 - 현재 선택 변경 노드 / 전체 변경 노드 갯수



| 변경 전 | 변경 후 |
| ---- | ---- |
|![image](https://github.com/Figci/Figci-Plugin-Client/assets/95596243/889d994a-8b8f-4a81-bd7e-c907b5ead135)|![image](https://github.com/Figci/Figci-Plugin-Client/assets/95596243/87b05966-5305-4283-a152-c2abbea3bdc6)|

 4. 페이지네이션 버튼 클릭 시 다음 변경 노드 선택 후 화면 이동

   ![페이지네이션-변경노드중심](
https://github.com/Fig[ci/Figci-Plugin-Client/assets/95596243/2ce38ceb-095c-41eb-b9ad-7d0785f07592](https://github.com/Figci/Figci-Plugin-Client/assets/95596243/2ce38ceb-095c-41eb-b9ad-7d0785f07592)
)

 5. 페이지네이션 변경 결과 존재 여부에 따라 버튼 비활성화

   ![페이지네이션- 비교불가 비활성화](
https://github.com/Figci/Figci-Plugin-[Client/assets/95596243/fd8511cb-2101-443e-81b3-fbfba8613290](https://github.com/Figci/Figci-Plugin-Client/assets/95596243/fd8511cb-2101-443e-81b3-fbfba8613290)
)

 6. 변경 노드 렌더시 첫번째 변경 노드 포커스

   ![첫번째 노드포커스](https://github.com/Figci/Figci-Plugin-Client/assets/95596243/6b019a2d-ab3f-444b-afe1-e2c4763ec3d0)

<br />

## 어떻게 해결했나요?

1. 이벤트에 따른 페이지네이션 정보 업데이트 주체가 달라진다.
 페이지가 변경 되었을때는 `클라이언트`에서 페이지네이션의 정보가 업데이트
 선택된 노드가 변경 되었을때는 `샌드박스`에서 페이지네이션의 정보가 업데이트

> 클라이언트에서 페이지네이션 업데이트

```
useEffect(() => {
   // 비교 결과 존재하지 않는 페이지인 경우
   if (diffingResult.result === "error") {
     setPagination({ result: false, frameCounts: "- / -" });
     
      return;
    }
    // 비교 결과 존재하는 페이지인 경우
    setPagination({
      result: true,
      currentCount: 0,
      frameCounts: Object.keys(differences).length,
    });
  }, [diffingResult]); // 변경 결과 상태 업데이트시 실행
```

> 서버에서 페이지네이션 업데이트

```
 // 선택된 노드 변경시 이벤트 발생
figma.on("selectionchange", () => {
  // 변경된 노드 갯수
  const totalFrameCount = differenceRectangleIdList.length;
 // 선택한 노드가 변경된 노드인 경우
  if (differenceRectangleIdList.includes(selectedNode.id)) {
    figma.ui.postMessage({
      type: "FRAME_PAGINATION",
      content: {
        result: true,
        currentCount: currentFrameIndex,
        frameCounts: totalFrameCount,
      },
    });
  } else {
    // 선택한 노드가 변경된 노드 아닌경우
    figma.ui.postMessage({
      type: "FRAME_PAGINATION",
      content: {
        result: true,
        currentCount: 0,
        frameCounts: totalFrameCount,
      },
    });
  }
});
```

2. 변경 결과 존재 여부에 따른 조건부 렌더링 - 버튼 비활성화
 활성화 된 버튼과 비활성화 된 버튼을 2개를 렌더하여서
 변경사항이 존재하는지 여부에 따라 분기 처리하여서 조건부 렌더링 된다.

```
// 페이지네이션 버튼 활성화 여부
const [isComparable, setIsComparable] = useState(false);

const isComparablePage = allPageIds.includes(pageId);

if (!isComparablePage) {
  setIsComparable(false);
}
setIsComparable(true);

// 변경 결과 존재 여부에 다른 조건부 렌더링
{isComparable ? (
  // 활성화 버튼 렌더링
 ) : (
  // 비활성화 버튼 렌더링
)}
```

4. postMessage 사이드 이펙트 처리
 버튼에서 발생하는 postMessage 메서드는 사이드 이펙트 처리를 해야한다.
 페이지네이션 버튼 클릭시 지역상태를 업데이트 하는 이벤트 핸들러 함수 작성
 useEffect 의존성으로 상태를 등록하여서 버튼 클릭시 `postMessage` 호출함.

```
const [isPaginationClicked, setIsPaginationClicked] = useState("");

useEffect(() => {
  if (isPaginationClicked.type === "prev") {
    postMessage("PREV_DIFFERENCE_RECTANGLE");
  }

  if (isPaginationClicked.type === "next") {
    postMessage("NEXT_DIFFERENCE_RECTANGLE");
  }
}, [isPaginationClicked]);
```

<br />

## 우려사항이 있나요?(선택사항)

1. URL입력 페이지 추가에 따른 글로벌 스토어로 부터 FileKey 수신 테스트 필요

<br />

## 잠깐! 확인해보셨나요?
- [x]  셀프 리뷰는 완료하셨나요?
- [x]  가장 최신 브랜치를 pull했나요?
- [x]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [x]  코드 컨벤션을 모두 지켰나요?
- [x]  적절한 라벨이 있나요?
- [x]  assignee가 있나요?