### PR TITLE
Fix: 버튼 재선택 선택시 버튼 비활성화, 페이지네이션 버튼 클릭 문제

### DIFF
--- a/src/ui/components/Difference/index.jsx
+++ b/src/ui/components/Difference/index.jsx
@@ -156,7 +156,11 @@ function Difference() {
       return;
     }
 
-    postMessage("PAGINATION_BUTTON", "next");
+    if (clickedType.type === "next") {
+      postMessage("PAGINATION_BUTTON", "next");
+
+      return;
+    }
   }, [clickedType]);
 
   return (
@@ -185,8 +189,6 @@ function Difference() {
           usingCase="void"
           handleClick={ev => {
             ev.preventDefault();
-
-            setPageId("");
 
             setIsOpenedPopup(true);
           }}


### PR DESCRIPTION
## Fix (이슈 번호)

None

<br />

## 해결하려던 문제를 알려주세요!
1. 비교 페이지 초기 마운트시  페이지 네이션 next 버튼 실행되면서
잠깐동안 페이네이션 숫자가 여러번 리렌더링 되는 문제 발생

2. 버튼 재선택 버튼 클릭후 취소 눌렀을때 버튼이 비활성화 되는 문제

<br />

## 어떻게 해결했나요?

1. 비교 페이지 초기 마운트시  페이지 네이션 next 버튼 실행되면서
잠깐동안 페이네이션 숫자가 여러번 리렌더링 되는 문제 발생
=> console 확인 결과 비교 페이지 마운트시 페이지네이션 다음 버튼이
클릭되고 있음이 확인 됬습니다.

![image](https://github.com/Figci/Figci-Plugin-Client/assets/95596243/8d51b800-addc-4e4f-9412-77cacd41c452)

현재 버튼타입 상태는 기본값이 설정되어있음으로
`const [clickedType, setClickedType] = useState({ type: "" });`
useEffect에서 의존하는  clickedType값이  truthy를 띄고 있으므로
초기 마운트시 한번 실행되는데 이때 next 버튼 타입의 분기처리가 되고있지 않았습니다.
```
if (clickedType.type === "prev") {
  postMessage("PAGINATION_BUTTON", "prev");

  return;
}
  postMessage("PAGINATION_BUTTON", "next"); // 초기마운트시 다음버튼 실행
}
```
=> 초기 마운트시 postMessage가 실행되는것을 방지하고자 버튼 타입을 명시하여서
분기처리를 추가했습니다.
```
if (clickedType.type === "prev") {
  postMessage("PAGINATION_BUTTON", "prev");

  return;
}

if (clickedType.type === "prev") {
  postMessage("PAGINATION_BUTTON", "next");

  return;
}
```

2. 버튼 재선택 버튼 클릭후 취소 눌렀을때 버튼이 비활성화 되는 문제
=> 페이지 재선택 버튼 눌렀을 경우 pageId Set 함수를 제거 했습니다.
```
handleClick={ev => {
  ev.preventDefault();
  // setPageId("");  페이지 아이디가 셋되면서 비교결과 호출에 실패하면서 버튼 비활성화
  setIsOpenedPopup(true);
}}
```

<br />

## 잠깐! 확인해보셨나요?

- [x]  셀프 리뷰는 완료하셨나요?
- [x]  가장 최신 브랜치를 pull했나요?
- [x]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [x]  코드 컨벤션을 모두 지켰나요?
- [x]  적절한 라벨이 있나요?
- [x]  assignee가 있나요?

