### PR TITLE
!HOTFIX:  토스트 렌더링 버그 수정

### DIFF
--- a/src/services/getDiffingResultQuery.js
+++ b/src/services/getDiffingResultQuery.js
@@ -39,6 +39,7 @@ const getDiffingResultQuery = (
   afterVersion,
   pageId,
   token,
+  isClick,
 ) => {
   return useQuery(
     `${beforeVersion}-${afterVersion}-${pageId}`,
@@ -56,7 +57,7 @@ const getDiffingResultQuery = (
     {
       cacheTime: 300000,
       staleTime: Infinity,
-      enabled: !!pageId,
+      enabled: isClick,
     },
   );
 };

--- a/src/ui/components/ProjectVersion/index.jsx
+++ b/src/ui/components/ProjectVersion/index.jsx
@@ -28,6 +28,7 @@ function ProjectVersion() {
   const [projectInformation, setProjectInformation] = useState({});
   const [selectedBefore, setSelectedBefore] = useState({});
   const [commonPageId, setCommonPageId] = useState("");
+  const [isClick, setIsClick] = useState(false);
 
   const { project, setProject } = useProjectStore();
   const { byDates, allDates } = useProjectVersionStore();
@@ -44,12 +45,14 @@ function ProjectVersion() {
     project.afterVersionId,
     commonPageId,
     projectInformation.accessToken,
+    isClick,
   );
 
   useEffect(() => {
-    if (diffingResult) {
+    if (diffingResult && isClick) {
       if (diffingResult.result === "error") {
         setToast({ status: true, message: diffingResult.message });
+        setIsClick(false);
 
         return;
       }
@@ -67,10 +70,11 @@ function ProjectVersion() {
       }
 
       postMessage("POST_DIFFING_RESULT", { differences, modifiedFrames });
+      setIsClick(false);
 
       navigate("/result");
     }
-  }, [diffingResult]);
+  }, [diffingResult, isClick]);
 
   const handleProjectInformation = ev => {
     setIsVersionLoading(true);
@@ -158,6 +162,7 @@ function ProjectVersion() {
     setPages(responseResult.content);
     setProject({ beforeVersionId: selectedBefore.beforeVersion });
     setCommonPageId(currentPageId);
+    setIsClick(true);
 
     setIsVersionLoading(false);
   };


### PR DESCRIPTION
## Fix (이슈 번호)
None

<br />

## 해결하려던 문제를 알려주세요!
에러토스트가 처음 1회는 잘 작동하지만, 연속적인 동일한 요청에 대해서 React Query가 캐싱된 값을 return할 때
useEffect가 실행되지 않음으로써 에러토스트가 렌더링 되지 않는 버그
![토스트 리렌더링 버그](https://github.com/Figci/Figci-Plugin-Client/assets/48385389/1f1983b2-ed48-45b2-9eaa-0f61c8a7fb87)


<br />

## 어떻게 해결했나요?
`isClick`이라는 `지역상태`를 선언하여, 클릭시에는 `true`가 되고, useEffect내부 로직이 실행되고 나면 `false`로 바뀌게끔 로직을 추가하였습니다.
`isClick`을 useEffect의 의존성배열에 추가하여 쿼리의 값 뿐만 아니라, compare버튼을 클릭함에 따라서 로직이 동작하게 수정하였습니다.

<br />

## 우려사항이 있나요?(선택사항)
특이사항 없습니다!

<br />

## 잠깐! 확인해보셨나요?

- [X]  셀프 리뷰는 완료하셨나요?
- [X]  가장 최신 브랜치를 pull했나요?
- [X]  base 브랜치명을 확인하셨나요? (Front, Backend, feature 등)
- [X]  코드 컨벤션을 모두 지켰나요?
- [X]  적절한 라벨이 있나요?
- [X]  assignee가 있나요?

<br />

## Attachment(선택사항) 
![버그 수정 후](https://github.com/Figci/Figci-Plugin-Client/assets/48385389/71aa8da2-0489-4dd1-84f9-2477d005841f)

→ 수정 후 렌더링 모습
<br />
